### PR TITLE
build(ide): configure VS Code

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,4 +1,8 @@
 {
   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=827846
-  "recommendations": ["angular.ng-template"]
+  "recommendations": [
+    "angular.ng-template",
+    "esbenp.prettier-vscode",
+    "spmeesseman.vscode-taskexplorer"
+  ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,14 +3,20 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "ng serve",
+      "name": "Install",
+      "type": "node-terminal",
+      "request": "launch",
+      "command": "npm install --legacy-peer-deps"
+    },
+    {
+      "name": "Dev Serve",
       "type": "chrome",
       "request": "launch",
       "preLaunchTask": "npm: start",
       "url": "http://localhost:4200/"
     },
     {
-      "name": "ng test",
+      "name": "All tests",
       "type": "chrome",
       "request": "launch",
       "preLaunchTask": "npm: test",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "format": "prettier --ignore-unknown --write",
     "format-all": "npm run format -- .",
     "generate-image-lists": "ts-node scripts/src/generate-image-lists.mts",
+    "postgenerate-image-lists": "npm run format -- src/data/images/**/*.json",
     "create-env-from-sample": "cp .env.sample .env",
     "lint-staged": "lint-staged",
     "git-hooks": "husky install"


### PR DESCRIPTION
Configures VSCode for the project:
- Same names as WebStorm for serve and test
- Add install launch config with `--legacy-peer-deps` trick
- Add Prettier and task explorer as recommended extensions
- Configure to format on save and to use prettier as default formatter
