### PR TITLE
feat(not-found): add not found page

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,28 +1,10 @@
 import { NgModule } from '@angular/core'
-import { RouterModule, Routes } from '@angular/router'
-import { ProjectsPageComponent } from './projects-page/projects-page.component'
-import { ProjectPageComponent } from './project-page/project-page.component'
-
-const projectsPath = 'projects'
-const routes: Routes = [
-  { path: '', redirectTo: projectsPath, pathMatch: 'full' },
-  {
-    path: `${projectsPath}/:slug`,
-    component: ProjectPageComponent,
-  },
-  {
-    path: projectsPath,
-    component: ProjectsPageComponent,
-  },
-  {
-    path: '**',
-    redirectTo: projectsPath,
-  },
-]
+import { RouterModule } from '@angular/router'
+import { ROUTES } from './routes'
 
 @NgModule({
   imports: [
-    RouterModule.forRoot(routes, {
+    RouterModule.forRoot(ROUTES, {
       initialNavigation: 'enabledBlocking',
       bindToComponentInputs: true,
     }),

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -16,6 +16,8 @@ import { IMAGEKIT_URL } from '../data/images/config' // There's no fancier way t
 import { SeoModule } from '@ngaox/seo'
 import meta from '../data/meta.json'
 import { ProjectPageComponent } from './project-page/project-page.component'
+import { NotFoundPageComponent } from './not-found-page/not-found-page.component'
+import { getCanonicalUrlForPath } from './routes'
 
 // There's no fancier way to install Web Components in Angular :P
 // https://stackoverflow.com/a/75353889/3263250
@@ -31,6 +33,7 @@ registerSwiper()
     LogoComponent,
     SwiperDirective,
     ProjectPageComponent,
+    NotFoundPageComponent,
   ],
   imports: [
     BrowserModule,
@@ -38,14 +41,10 @@ registerSwiper()
     NgOptimizedImage,
     HttpClientModule,
     SeoModule.forRoot({
-      title: meta.siteName,
-      keywords: meta.keywords,
-      description: meta.description,
-      url: meta.canonicalUrl,
       type: 'website',
       image: {
-        url: new URL('assets/img/open_graph.png', meta.canonicalUrl).toString(),
-        alt: meta.imageAlt,
+        url: getCanonicalUrlForPath('assets/img/open_graph.png'),
+        alt: meta.default.imageAlt,
         width: 875,
         height: 875,
         // I wouldn't set it, but if I don't set it, then it appears as "undefined" :(
@@ -53,16 +52,16 @@ registerSwiper()
       },
       twitter: {
         card: 'summary',
-        creator: meta.author,
-        site: meta.siteName,
+        creator: `@${meta.default.twitter}`,
+        site: `@${meta.default.twitter}`,
       },
-      siteName: meta.siteName,
+      siteName: meta.default.siteName,
       extra: [
-        { name: 'author', content: meta.author },
+        { name: 'author', content: meta.default.author },
         { property: 'og:locale', content: 'en' },
         { name: 'generator', content: `Angular ${VERSION.full}` },
         // See more in favicons doc. Related to Internet Explorer / Microsoft metro tiles
-        { name: 'application-name', content: meta.siteName },
+        { name: 'application-name', content: meta.default.siteName },
       ],
     }),
   ],

--- a/src/app/not-found-page/not-found-page.component.html
+++ b/src/app/not-found-page/not-found-page.component.html
@@ -1,0 +1,3 @@
+<span class="sad-face">(◡︵◡)</span>
+<h2>Error 404</h2>
+<p>{{ description }}</p>

--- a/src/app/not-found-page/not-found-page.component.scss
+++ b/src/app/not-found-page/not-found-page.component.scss
@@ -1,0 +1,22 @@
+@use 'margins';
+@use 'typographies';
+
+:host {
+  display: flex;
+  flex-direction: column;
+  place-content: center;
+  text-align: center;
+
+  margin-top: margins.$l;
+
+  .sad-face {
+    @include typographies.size(10);
+    @include typographies.bold;
+    margin-bottom: margins.$m;
+  }
+
+  h2 {
+    @include typographies.size(8);
+    @include typographies.bold;
+  }
+}

--- a/src/app/not-found-page/not-found-page.component.spec.ts
+++ b/src/app/not-found-page/not-found-page.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+
+import { NotFoundPageComponent } from './not-found-page.component'
+
+describe('NotFoundPageComponent', () => {
+  let component: NotFoundPageComponent
+  let fixture: ComponentFixture<NotFoundPageComponent>
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [NotFoundPageComponent],
+    })
+    fixture = TestBed.createComponent(NotFoundPageComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+})

--- a/src/app/not-found-page/not-found-page.component.ts
+++ b/src/app/not-found-page/not-found-page.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core'
+import meta from '../../data/meta.json'
+
+@Component({
+  selector: 'app-not-found-page',
+  templateUrl: './not-found-page.component.html',
+  styleUrls: ['./not-found-page.component.scss'],
+})
+export class NotFoundPageComponent {
+  public readonly description: string = meta.notFound.description
+}

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -1,0 +1,57 @@
+import { Routes } from '@angular/router'
+import { ProjectPageComponent } from './project-page/project-page.component'
+import { ProjectsPageComponent } from './projects-page/projects-page.component'
+import { NotFoundPageComponent } from './not-found-page/not-found-page.component'
+import { IPageSeoData } from '@ngaox/seo'
+import meta from '../data/meta.json'
+
+const PROJECTS_PATH = 'projects'
+const NOT_FOUND_DATA: RouteData = {
+  NgaoxSeo: {
+    title: getTitle(meta.notFound.title),
+    description: meta.notFound.description,
+    image: undefined,
+  },
+}
+const NOT_FOUND_PATH = '404'
+export const ROUTES: Routes = [
+  {
+    path: '',
+    component: ProjectsPageComponent,
+    data: {
+      NgaoxSeo: {
+        title: meta.default.siteName,
+        description: meta.default.description,
+        keywords: meta.default.keywords,
+        url: getCanonicalUrlForPath(''),
+      },
+    },
+    pathMatch: 'full',
+  },
+  {
+    path: `${PROJECTS_PATH}/:slug`,
+    component: ProjectPageComponent,
+  },
+  {
+    path: NOT_FOUND_PATH,
+    component: NotFoundPageComponent,
+    data: {
+      NOT_FOUND_DATA,
+      url: getCanonicalUrlForPath(NOT_FOUND_PATH),
+    },
+  },
+  {
+    path: '**',
+    component: NotFoundPageComponent,
+    data: NOT_FOUND_DATA,
+  },
+]
+type RouteData = { NgaoxSeo?: IPageSeoData }
+
+export function getCanonicalUrlForPath(path: string) {
+  return new URL(path, new URL(meta.default.canonicalUrl)).toString()
+}
+
+function getTitle(title: string) {
+  return `${title} | ${meta.default.siteName}`
+}

--- a/src/data/meta.json
+++ b/src/data/meta.json
@@ -1,8 +1,15 @@
 {
-  "siteName": "Christian Lazaro",
-  "author": "Christian Lazaro",
-  "description": "Fashion designer and stylist, @christian_labu",
-  "keywords": "fashion design, stylist, art, photography, projects, christian_labu",
-  "canonicalUrl": "https://christianlazaro.es/",
-  "imageAlt": "LAZARO. In uppercase letters. Surrounded by yellow decorations"
+  "default": {
+    "siteName": "Christian Lazaro",
+    "author": "Christian Lazaro",
+    "description": "Fashion designer and stylist, @christian_labu",
+    "keywords": "fashion design, stylist, art, photography, projects, christian_labu",
+    "canonicalUrl": "https://christianlazaro.es/",
+    "imageAlt": "LAZARO. In uppercase letters. Surrounded by yellow decorations",
+    "twitter": "christhefruit"
+  },
+  "notFound": {
+    "title": "Not Found",
+    "description": "The requested content could not be found"
+  }
 }


### PR DESCRIPTION
Adds not found page with its metadata

## Features
- Add not found page
- Customize not found page title, description and (lack of) image
- Unknown routes to show not found page
- Add not found route as 404
- Add twitter username for twitter card

## Refactor
- Move all metadata inside "default" key
- Add metadata for not found page
- Split routes data into `routes.ts` to be able to look for path consts when navigating
- Add functions to fabricate metadata (canonical URL and title using strategy)
