### PR TITLE
chore: set dummy alt text

### DIFF
--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -10,7 +10,6 @@ module.exports = {
     assert: {
       preset: 'lighthouse:no-pwa',
       assertions: {
-        'image-alt': 'warn',
         'bf-cache': 'warn',
         'csp-xss': 'warn',
         'unused-javascript': 'warn',

--- a/src/app/projects-page/project-item/project-item.component.html
+++ b/src/app/projects-page/project-item/project-item.component.html
@@ -35,14 +35,13 @@
   >
     <!-- TODO: a11y -->
     <!-- Keep in sync with breakpoints SCSS. srcset subset from Angular defaults -->
-    <!--suppress HtmlRequiredAltAttribute -->
-    <!-- eslint-disable-next-line @angular-eslint/template/alt-text -->
     <img
       [ngSrc]="image.filePath"
       ngSrcset="128w, 256w, 384w, 640w, 750w, 828w, 1080w, 1200w, 1920w"
       sizes="(max-width: 959.98px) 50vw, 33vw"
       [fill]="true"
       [priority]="priorityPreviewImages && i < SLIDES_PER_VIEW"
+      alt="Image"
     />
   </swiper-slide>
 </swiper-container>

--- a/src/data/images/projects-lookbooks.json
+++ b/src/data/images/projects-lookbooks.json
@@ -5,36 +5,31 @@
         "name": "lookbook01.jpg",
         "filePath": "/projects/chiasma/lookbooks/1/lookbook01.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook02.jpg",
         "filePath": "/projects/chiasma/lookbooks/1/lookbook02.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook03.jpg",
         "filePath": "/projects/chiasma/lookbooks/1/lookbook03.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook04.jpg",
         "filePath": "/projects/chiasma/lookbooks/1/lookbook04.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook05.jpg",
         "filePath": "/projects/chiasma/lookbooks/1/lookbook05.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       }
     ],
     [
@@ -42,71 +37,61 @@
         "name": "lookbook06.jpg",
         "filePath": "/projects/chiasma/lookbooks/2/lookbook06.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook07.jpg",
         "filePath": "/projects/chiasma/lookbooks/2/lookbook07.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook08.jpg",
         "filePath": "/projects/chiasma/lookbooks/2/lookbook08.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook09.jpg",
         "filePath": "/projects/chiasma/lookbooks/2/lookbook09.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook10.jpg",
         "filePath": "/projects/chiasma/lookbooks/2/lookbook10.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook11.jpg",
         "filePath": "/projects/chiasma/lookbooks/2/lookbook11.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook12.jpg",
         "filePath": "/projects/chiasma/lookbooks/2/lookbook12.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook13.jpg",
         "filePath": "/projects/chiasma/lookbooks/2/lookbook13.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook14.jpg",
         "filePath": "/projects/chiasma/lookbooks/2/lookbook14.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook15.jpg",
         "filePath": "/projects/chiasma/lookbooks/2/lookbook15.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       }
     ],
     [
@@ -114,36 +99,31 @@
         "name": "lookbook16.jpg",
         "filePath": "/projects/chiasma/lookbooks/3/lookbook16.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook17.jpg",
         "filePath": "/projects/chiasma/lookbooks/3/lookbook17.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook18.jpg",
         "filePath": "/projects/chiasma/lookbooks/3/lookbook18.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook19.jpg",
         "filePath": "/projects/chiasma/lookbooks/3/lookbook19.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook20.jpg",
         "filePath": "/projects/chiasma/lookbooks/3/lookbook20.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       }
     ],
     [
@@ -151,85 +131,73 @@
         "name": "lookbook21.jpg",
         "filePath": "/projects/chiasma/lookbooks/4/lookbook21.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook22.jpg",
         "filePath": "/projects/chiasma/lookbooks/4/lookbook22.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook23.jpg",
         "filePath": "/projects/chiasma/lookbooks/4/lookbook23.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook24.jpg",
         "filePath": "/projects/chiasma/lookbooks/4/lookbook24.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook25.jpg",
         "filePath": "/projects/chiasma/lookbooks/4/lookbook25.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook26.jpg",
         "filePath": "/projects/chiasma/lookbooks/4/lookbook26.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook27.jpg",
         "filePath": "/projects/chiasma/lookbooks/4/lookbook27.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook28.jpg",
         "filePath": "/projects/chiasma/lookbooks/4/lookbook28.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook29.jpg",
         "filePath": "/projects/chiasma/lookbooks/4/lookbook29.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook30.jpg",
         "filePath": "/projects/chiasma/lookbooks/4/lookbook30.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook31.jpg",
         "filePath": "/projects/chiasma/lookbooks/4/lookbook31.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook32.jpg",
         "filePath": "/projects/chiasma/lookbooks/4/lookbook32.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       }
     ],
     [
@@ -237,78 +205,67 @@
         "name": "lookbook33.jpg",
         "filePath": "/projects/chiasma/lookbooks/5/lookbook33.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook34.jpg",
         "filePath": "/projects/chiasma/lookbooks/5/lookbook34.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook35.jpg",
         "filePath": "/projects/chiasma/lookbooks/5/lookbook35.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook36.jpg",
         "filePath": "/projects/chiasma/lookbooks/5/lookbook36.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook37.jpg",
         "filePath": "/projects/chiasma/lookbooks/5/lookbook37.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook38.jpg",
         "filePath": "/projects/chiasma/lookbooks/5/lookbook38.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook39.jpg",
         "filePath": "/projects/chiasma/lookbooks/5/lookbook39.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook40.jpg",
         "filePath": "/projects/chiasma/lookbooks/5/lookbook40.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook41.jpg",
         "filePath": "/projects/chiasma/lookbooks/5/lookbook41.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook42.jpg",
         "filePath": "/projects/chiasma/lookbooks/5/lookbook42.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       },
       {
         "name": "lookbook43.jpg",
         "filePath": "/projects/chiasma/lookbooks/5/lookbook43.jpg",
         "height": 1560,
-        "width": 1040,
-        "alt": "Image"
+        "width": 1040
       }
     ]
   ]


### PR DESCRIPTION
Some of the images from CDN (lookbook images) provide a dummy default `alt` text (lookbooks). But not for others (preview images). As the `alt` metadata with its dummy default was added later.

In order to save some bytes of JSON (dummy default around), removing the dummy default `alt` in image CDN. And removed all dummy default `alt` from images except logo one (which is appropriate).

But to pass the `alt` lighthouse test, providing the dummy default `alt` in the template instead.
