### PR TITLE
refactor(images): improve images list script

### DIFF
--- a/scripts/src/generate-image-lists.mts
+++ b/scripts/src/generate-image-lists.mts
@@ -4,188 +4,220 @@ import { FileObject } from 'imagekit/dist/libs/interfaces'
 import * as fs from 'fs'
 import imagesConfigPkg from '../../src/data/images/config.js'
 import { ImageAsset } from '../../src/data/images/types.js'
-import * as url from 'url'
-import { fileURLToPath } from 'url'
 import path from 'path'
+import { isMain } from './is-main.mjs'
+import { getRepositoryRootDir } from './get-repository-root-dir.mjs'
+import { Log } from './log.mjs'
 
 const { IMAGEKIT_URL } = imagesConfigPkg
 
-async function generateImageLists() {
-  const imagekit = getImagekit()
-  await generateLogoImagesList(imagekit)
-  await generateProjectsPreviewImagesList(imagekit)
-}
+class ImageListsGenerator {
+  private imageKit: ImageKit
+  private readonly IMAGES_DATA_DIR = path.join(
+    getRepositoryRootDir(),
+    'src',
+    'data',
+    'images',
+  )
 
-async function generateLogoImagesList(imagekit: ImageKit) {
-  console.info('⚙️ Looking for logo images')
-  const LOGOS_PATH = 'logos'
-  const logoFileObjects = await imagekit.listFiles({ path: LOGOS_PATH })
-  if (logoFileObjects.length === 0) {
-    console.error("No logo files found within path '%s'", LOGOS_PATH)
-    process.exit(1)
+  constructor() {
+    this.imageKit = ImageListsGenerator.getImageKit()
   }
-  console.log('Found %d logo files', logoFileObjects.length)
 
-  const HORIZONTAL_LOGO_FILENAME = 'horizontal.png'
-  console.info(
-    "Looking for horizontal logo image ('%s')",
-    HORIZONTAL_LOGO_FILENAME,
-  )
-  const horizontalLogoFileObject = logoFileObjects.find((fileObject) =>
-    fileObject.filePath.endsWith(HORIZONTAL_LOGO_FILENAME),
-  )
-  if (!horizontalLogoFileObject) {
-    console.error(
-      "Horizontal logo file with name '%s' could not be found",
+  private static getImageKit(): ImageKit {
+    dotenv.config()
+
+    const { IMAGEKIT_PUBLIC_KEY, IMAGEKIT_PRIVATE_KEY } = process.env
+    if (!IMAGEKIT_PUBLIC_KEY || !IMAGEKIT_PRIVATE_KEY) {
+      Log.error('Either ImageKit URL, public key or private key is missing')
+      Log.error('Add them to the .env file and try again')
+      process.exit(1)
+    }
+
+    return new ImageKit({
+      urlEndpoint: IMAGEKIT_URL,
+      publicKey: IMAGEKIT_PUBLIC_KEY,
+      privateKey: IMAGEKIT_PRIVATE_KEY,
+    })
+  }
+
+  public async all(): Promise<void> {
+    await this.logos()
+    const projects = await this.projects()
+    await this.projectsPreviewImages(projects)
+    await this.projectsLookbooksImages(projects)
+  }
+
+  private async logos(): Promise<void> {
+    Log.group('Logo images')
+    const LOGOS_PATH = 'logos'
+    const logoFileObjects = await this.imageKit.listFiles({ path: LOGOS_PATH })
+    if (logoFileObjects.length === 0) {
+      Log.error("No logo files found within path '%s'", LOGOS_PATH)
+      process.exit(1)
+    }
+    Log.info('Found %d logo files', logoFileObjects.length)
+
+    const HORIZONTAL_LOGO_FILENAME = 'horizontal.png'
+    Log.info(
+      "Looking for horizontal logo image ('%s')",
       HORIZONTAL_LOGO_FILENAME,
     )
-    process.exit(1)
-  }
-
-  console.info('✅  Horizontal logo found')
-  const logoImages: { [id: string]: ImageAsset } = {
-    horizontal: imageAssetFromFileObject(horizontalLogoFileObject),
-  }
-  writeData(logoImages, 'logos.json')
-  console.info('✅  Logo images list done')
-  console.log('')
-}
-
-async function generateProjectsPreviewImagesList(imagekit: ImageKit) {
-  const PROJECTS_PATH = 'projects'
-  console.info("⚙️ Looking for project directories inside '%s'", PROJECTS_PATH)
-  const projectFileObjects = await imagekit.listFiles({
-    includeFolder: true,
-    path: PROJECTS_PATH,
-  })
-  if (projectFileObjects.length === 0) {
-    console.error(
-      "No project directories found within path '%s'",
-      PROJECTS_PATH,
+    const horizontalLogoFileObject = logoFileObjects.find((fileObject) =>
+      fileObject.filePath.endsWith(HORIZONTAL_LOGO_FILENAME),
     )
-    process.exit(1)
-  }
-  console.info('Found %d project directories', projectFileObjects.length)
-  projectFileObjects.forEach((projectFileObject) => {
-    console.log(' - %s', projectFileObject.name)
-  })
-  console.info('✅  Project directories done')
-  console.log('')
-
-  await getProjectsPreviewImages(imagekit, projectFileObjects)
-  await getProjectsLookbookImages(imagekit, projectFileObjects)
-}
-
-async function getProjectsPreviewImages(
-  imagekit: ImageKit,
-  projectFileObjects: ReadonlyArray<FileObject>,
-) {
-  console.info('⚙️ Looking for projects preview images')
-  const projectsPreviewImages: {
-    [slug: string]: ReadonlyArray<ImageAsset>
-  } = Object.fromEntries(
-    await Promise.all(
-      projectFileObjects.map(async (projectFileObject) => {
-        const projectFolderObject = projectFileObject as unknown as FolderObject
-        const PREVIEWS_DIR = 'preview'
-        console.info(
-          "Finding preview images of project '%s' ('%s')",
-          projectFolderObject.name,
-          projectFolderObject.folderPath,
-        )
-        const projectPreviewFileObjects = await imagekit.listFiles({
-          path: `${projectFolderObject.folderPath}/${PREVIEWS_DIR}`,
-          sort: 'ASC_NAME',
-        })
-        console.log(' - Found %d images', projectPreviewFileObjects.length)
-        return [
-          projectFolderObject.name,
-          projectPreviewFileObjects.map(imageAssetFromFileObject),
-        ]
-      }),
-    ),
-  )
-  writeData(projectsPreviewImages, 'projects-preview.json')
-  console.info('✅  Projects preview images done')
-  console.log('')
-}
-
-async function getProjectsLookbookImages(
-  imagekit: ImageKit,
-  projectFileObjects: ReadonlyArray<FileObject>,
-) {
-  type Lookbook = ReadonlyArray<ImageAsset>
-  const projectsLookbooks: {
-    [slug: string]: ReadonlyArray<Lookbook>
-  } = {}
-  console.info('⚙️ Looking for projects lookbooks images')
-  for (const projectFileObject of projectFileObjects) {
-    const projectFolderObject = projectFileObject as unknown as FolderObject
-    const LOOKBOOKS_DIR = 'lookbooks'
-    console.info(
-      "Finding lookbooks of project '%s' ('%s')",
-      projectFolderObject.name,
-      projectFolderObject.folderPath,
-    )
-    const lookbooksFileObjects = await imagekit.listFiles({
-      path: `${projectFolderObject.folderPath}/${LOOKBOOKS_DIR}`,
-      includeFolder: true,
-      sort: 'ASC_NAME',
-    })
-    const lookbooksFolderObjects =
-      lookbooksFileObjects as unknown as ReadonlyArray<FolderObject>
-    if (lookbooksFolderObjects.length < 1) {
-      console.log(
-        " - No lookbooks found for project '%s'",
-        projectFolderObject.name,
+    if (!horizontalLogoFileObject) {
+      Log.error(
+        "Horizontal logo file with name '%s' could not be found",
+        HORIZONTAL_LOGO_FILENAME,
       )
-      continue
+      process.exit(1)
     }
-    console.log(' - Found %d lookbooks', lookbooksFolderObjects.length)
-    console.log('')
-    const lookbookAssets: ImageAsset[][] = []
-    for (const lookbookFolderObject of lookbooksFolderObjects) {
-      console.log(
-        " - Finding lookbook '%s' image assets",
-        lookbookFolderObject.name,
+
+    Log.ok('Horizontal logo found')
+    const logoImages: { [id: string]: ImageAsset } = {
+      horizontal: this.imageAssetFromFileObject(horizontalLogoFileObject),
+    }
+    this.writeJson(logoImages, 'logos.json')
+    Log.ok('Done')
+    Log.groupEnd()
+  }
+
+  private async projects(): Promise<ReadonlyArray<FolderObject>> {
+    const PROJECTS_PATH = 'projects'
+    Log.group("Project directories (inside '%s')", PROJECTS_PATH)
+    const projectFileObjects = await this.imageKit.listFiles({
+      includeFolder: true,
+      path: PROJECTS_PATH,
+    })
+    if (projectFileObjects.length === 0) {
+      Log.error("No project directories found within path '%s'", PROJECTS_PATH)
+      process.exit(1)
+    }
+    Log.info('Found %d project directories', projectFileObjects.length)
+    projectFileObjects.forEach((projectFileObject) => {
+      Log.item(projectFileObject.name)
+    })
+    Log.ok('Done')
+    Log.groupEnd()
+    return projectFileObjects as unknown as ReadonlyArray<FolderObject>
+  }
+
+  private async projectsPreviewImages(
+    projectFolderObjects: ReadonlyArray<FolderObject>,
+  ): Promise<void> {
+    Log.group('Projects preview images')
+    const projectsPreviewImages: {
+      [slug: string]: ReadonlyArray<ImageAsset>
+    } = Object.fromEntries(
+      await Promise.all(
+        projectFolderObjects.map(async (projectFolderObject) => {
+          const PREVIEWS_DIR = 'preview'
+          Log.info(
+            "Finding preview images of project '%s' ('%s')",
+            projectFolderObject.name,
+            projectFolderObject.folderPath,
+          )
+          const projectPreviewFileObjects = await this.imageKit.listFiles({
+            path: `${projectFolderObject.folderPath}/${PREVIEWS_DIR}`,
+            sort: 'ASC_NAME',
+          })
+          if (projectPreviewFileObjects.length < 1) {
+            Log.warn(
+              "No preview images found for project '%s'",
+              projectFolderObject.name,
+            )
+          } else {
+            Log.item(
+              'Found %d preview images',
+              projectPreviewFileObjects.length,
+            )
+          }
+          return [
+            projectFolderObject.name,
+            projectPreviewFileObjects.map(this.imageAssetFromFileObject),
+          ]
+        }),
+      ),
+    )
+    this.writeJson(projectsPreviewImages, 'projects-preview.json')
+    Log.ok('Done')
+    Log.groupEnd()
+  }
+
+  private async projectsLookbooksImages(
+    projectFolderObjects: ReadonlyArray<FolderObject>,
+  ) {
+    type Lookbook = ReadonlyArray<ImageAsset>
+    const projectsLookbooks: {
+      [slug: string]: ReadonlyArray<Lookbook>
+    } = {}
+    Log.group('Projects lookbooks images')
+    for (const projectFolderObject of projectFolderObjects) {
+      const LOOKBOOKS_DIR = 'lookbooks'
+      Log.info(
+        "Finding lookbooks of project '%s' ('%s')",
+        projectFolderObject.name,
+        projectFolderObject.folderPath,
       )
-      const lookbookFileObjects = await imagekit.listFiles({
-        path: lookbookFolderObject.folderPath,
+      const lookbooksFileObjects = await this.imageKit.listFiles({
+        path: `${projectFolderObject.folderPath}/${LOOKBOOKS_DIR}`,
+        includeFolder: true,
         sort: 'ASC_NAME',
       })
-      lookbookAssets.push(lookbookFileObjects.map(imageAssetFromFileObject))
+      const lookbooksFolderObjects =
+        lookbooksFileObjects as unknown as ReadonlyArray<FolderObject>
+      if (lookbooksFolderObjects.length < 1) {
+        Log.warn(
+          "No lookbooks found for project '%s'",
+          projectFolderObject.name,
+        )
+        continue
+      }
+      Log.item('Found %d lookbooks', lookbooksFolderObjects.length)
+      const lookbookAssets: ImageAsset[][] = []
+      for (const lookbookFolderObject of lookbooksFolderObjects) {
+        Log.group(
+          "Project '%s' lookbook '%s' images",
+          projectFolderObject.name,
+          lookbookFolderObject.name,
+        )
+        const lookbookFileObjects = await this.imageKit.listFiles({
+          path: lookbookFolderObject.folderPath,
+          sort: 'ASC_NAME',
+        })
+        if (lookbooksFileObjects.length < 1) {
+          Log.warn("No images for lookbook '%s'", lookbookFolderObject.name)
+        } else {
+          Log.item('Found %d images', lookbookFileObjects.length)
+        }
+        lookbookAssets.push(
+          lookbookFileObjects.map(this.imageAssetFromFileObject),
+        )
+        Log.groupEnd()
+      }
+      projectsLookbooks[projectFolderObject.name] = lookbookAssets
     }
-    projectsLookbooks[projectFolderObject.name] = lookbookAssets
-  }
-  writeData(projectsLookbooks, 'projects-lookbooks.json')
-  console.info('✅  Projects lookbooks images done')
-  console.log('')
-}
-
-function getImagekit(): ImageKit {
-  dotenv.config()
-
-  const { IMAGEKIT_PUBLIC_KEY, IMAGEKIT_PRIVATE_KEY } = process.env
-  if (!IMAGEKIT_PUBLIC_KEY || !IMAGEKIT_PRIVATE_KEY) {
-    console.error('Either ImageKit URL, public key or private key is missing')
-    console.error('Add them to the .env file and try again')
-    process.exit(1)
+    this.writeJson(projectsLookbooks, 'projects-lookbooks.json')
+    Log.ok('Done')
+    Log.groupEnd()
   }
 
-  return new ImageKit({
-    urlEndpoint: IMAGEKIT_URL,
-    publicKey: IMAGEKIT_PUBLIC_KEY,
-    privateKey: IMAGEKIT_PRIVATE_KEY,
-  })
-}
+  private imageAssetFromFileObject(fileObject: FileObject): ImageAsset {
+    return {
+      name: fileObject.name,
+      filePath: fileObject.filePath,
+      height: fileObject.height,
+      width: fileObject.width,
+      alt: (fileObject.customMetadata as CustomMetadata)?.alt,
+    }
+  }
 
-function imageAssetFromFileObject(fileObject: FileObject): ImageAsset {
-  return {
-    name: fileObject.name,
-    filePath: fileObject.filePath,
-    height: fileObject.height,
-    width: fileObject.width,
-    alt: (fileObject.customMetadata as CustomMetadata)?.alt,
+  private writeJson(json: object, filename: string): void {
+    fs.writeFileSync(
+      path.join(this.IMAGES_DATA_DIR, filename),
+      JSON.stringify(json, null, 2),
+    )
   }
 }
 
@@ -201,37 +233,8 @@ type CustomMetadata = {
   alt?: string
 }
 
-function writeData(data: object, filename: string): void {
-  fs.writeFileSync(
-    path.join(IMAGES_DATA_DIR, filename),
-    JSON.stringify(data, null, 2),
-  )
-}
-
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename)
-
-export function getRepositoryRootDir() {
-  return path.resolve(__dirname, '..', '..')
-}
-
-const IMAGES_DATA_DIR = path.join(
-  getRepositoryRootDir(),
-  'src',
-  'data',
-  'images',
-)
-
-/**
- * isMain(import.meta.url)
- * https://2ality.com/2022/07/nodejs-esm-main.html
- */
-export function isMain(importMetaUrl: string) {
-  const modulePath = url.fileURLToPath(importMetaUrl)
-  return process.argv[1] === modulePath
-}
-
 if (isMain(import.meta.url)) {
-  await generateImageLists()
-  console.info('✅  Done')
+  const imageListsGenerator = new ImageListsGenerator()
+  await imageListsGenerator.all()
+  Log.ok('All done')
 }

--- a/scripts/src/get-repository-root-dir.mts
+++ b/scripts/src/get-repository-root-dir.mts
@@ -1,0 +1,9 @@
+import { fileURLToPath } from 'url'
+import path from 'path'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+export function getRepositoryRootDir() {
+  return path.resolve(__dirname, '..', '..')
+}

--- a/scripts/src/is-main.mts
+++ b/scripts/src/is-main.mts
@@ -1,0 +1,10 @@
+import * as url from 'url'
+
+/**
+ * isMain(import.meta.url)
+ * https://2ality.com/2022/07/nodejs-esm-main.html
+ */
+export function isMain(importMetaUrl: string) {
+  const modulePath = url.fileURLToPath(importMetaUrl)
+  return process.argv[1] === modulePath
+}

--- a/scripts/src/log.mts
+++ b/scripts/src/log.mts
@@ -1,0 +1,29 @@
+export class Log implements Partial<Console> {
+  static info(message: string, ...params: unknown[]) {
+    console.info(`ℹ️ ${message}`, ...params)
+  }
+
+  static item(message: string, ...params: unknown[]) {
+    console.info(`    - ${message}`, ...params)
+  }
+
+  static warn(message: string, ...params: unknown[]) {
+    console.warn(`⚠️ ${message}`, ...params)
+  }
+
+  static group(label: string, ...params: unknown[]) {
+    console.group(`🏷️${label}`, ...params)
+  }
+
+  static groupEnd() {
+    console.groupEnd()
+  }
+
+  static ok(message: string, ...params: unknown[]) {
+    console.info(`✅  ${message}`, ...params)
+  }
+
+  static error(message: string, ...params: unknown[]) {
+    console.error(`❌  ${message}`, ...params)
+  }
+}


### PR DESCRIPTION
Refactor to improves images listing script:
 - Use class to share `imageKit` SDK obj around
 - Move all generators inside class
 - Extract method to list project directories
 - Cast once to folder objects, use around
 - Extract utils into separate files
 - Import logger and use it around

Ran the script several times: no changes, so everything's fine

Sample of beautified logs: 💅

![image](https://github.com/davidlj95/chrislb/assets/8050648/65ba557c-4387-4a45-95b1-e3e00b36a28f)

