### PR TITLE
feat(projects): render lookbooks in detail view

### DIFF
--- a/src/app/common/default-image-alt.ts
+++ b/src/app/common/default-image-alt.ts
@@ -1,0 +1,1 @@
+export const DEFAULT_IMAGE_ALT = 'Image'

--- a/src/app/project-page/project-lookbooks.service.ts
+++ b/src/app/project-page/project-lookbooks.service.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable, InjectionToken } from '@angular/core'
 import { ImageAsset } from '../../data/images/types'
 import projectsLookbooks from '../../data/images/projects-lookbooks.json'
+import { Observable, of } from 'rxjs'
 
 @Injectable({
   providedIn: 'root',
@@ -11,12 +12,12 @@ export class ProjectLookbooksService {
     private projectLookbooksJson: ProjectsLookbooksJson,
   ) {}
 
-  async bySlug(slug: string): Promise<ReadonlyArray<Lookbook>> {
+  bySlug(slug: string): Observable<ReadonlyArray<ReadonlyArray<ImageAsset>>> {
     if (!this.projectSlugExists(slug)) {
       console.warn("No lookbooks found for project slug '%s'", slug)
-      return []
+      return of([])
     }
-    return this.projectLookbooksJson[slug]
+    return of(this.projectLookbooksJson[slug])
   }
 
   projectSlugExists(slug: string): slug is ProjectSlug {
@@ -32,4 +33,3 @@ const PROJECT_PREVIEW_IMAGES_JSON = new InjectionToken<ProjectsLookbooksJson>(
 )
 type ProjectsLookbooksJson = typeof projectsLookbooks
 type ProjectSlug = keyof ProjectsLookbooksJson
-export type Lookbook = ReadonlyArray<ImageAsset>

--- a/src/app/project-page/project-page.component.html
+++ b/src/app/project-page/project-page.component.html
@@ -1,4 +1,26 @@
-<main>
-  <p>Project lookbooks</p>
-  <pre>{{ lookbooks | async | json }}</pre>
-</main>
+<div
+  class="lookbook"
+  *ngFor="let lookbook of lookbooks | async; index as lookbookIndex"
+>
+  <h2>Lookbook {{ lookbookIndex + 1 }}</h2>
+  <swiper-container [appSwiper]="lookbook.swiperOptions" init="false">
+    <swiper-slide
+      *ngFor="let image of lookbook.images; index as imageIndex"
+      [style.aspect-ratio]="image.width / image.height"
+    >
+      <!-- TODO: a11y -->
+      <!-- Keep in sync with breakpoints SCSS. srcset subset from Angular defaults -->
+      <img
+        [ngSrc]="image.filePath"
+        ngSrcset="128w, 256w, 384w, 640w, 750w, 828w, 1080w, 1200w, 1920w"
+        sizes="(max-width: 959.98px) 50vw, 33vw"
+        [fill]="true"
+        [priority]="
+          lookbookIndex < MAX_LOOKBOOKS_PER_VIEWPORT &&
+          imageIndex < MAX_SLIDES_PER_VIEW
+        "
+        [alt]="image.alt ?? DEFAULT_IMAGE_ALT"
+      />
+    </swiper-slide>
+  </swiper-container>
+</div>

--- a/src/app/project-page/project-page.component.scss
+++ b/src/app/project-page/project-page.component.scss
@@ -1,8 +1,32 @@
+@use 'header';
+@use 'logo';
 @use 'page';
+@use 'swiper';
+@use 'margins';
 
 :host {
   @include page.padding;
 
   display: flex;
   flex-direction: column;
+  gap: margins.$m;
+  text-align: center;
+
+  @include swiper.theme;
+
+  swiper-container {
+    $height-header: header.$height;
+    $height-logo: logo.$height;
+    $height-page-padding: page.$padding-vertical;
+    $height-before: calc($height-header + $height-logo + $height-page-padding);
+    $extra-space: margins.$xl;
+
+    swiper-slide {
+      max-height: calc(100vh - $height-before - $extra-space) !important;
+
+      img {
+        object-fit: contain;
+      }
+    }
+  }
 }

--- a/src/app/project-page/project-page.component.ts
+++ b/src/app/project-page/project-page.component.ts
@@ -1,8 +1,11 @@
 import { Component, Input } from '@angular/core'
-import { Lookbook, ProjectLookbooksService } from './project-lookbooks.service'
+import { ProjectLookbooksService } from './project-lookbooks.service'
 import { Router } from '@angular/router'
-import { noop } from 'rxjs'
+import { map, noop, Observable, tap } from 'rxjs'
 import { displayNotFound } from '../common/navigation'
+import { SwiperOptions } from 'swiper/types'
+import { ImageAsset } from '../../data/images/types'
+import { DEFAULT_IMAGE_ALT } from '../common/default-image-alt'
 
 @Component({
   selector: 'app-project-page',
@@ -10,22 +13,65 @@ import { displayNotFound } from '../common/navigation'
   styleUrls: ['./project-page.component.scss'],
 })
 export class ProjectPageComponent {
-  @Input({ required: true })
-  public set slug(slug: string) {
-    this.lookbooks = this.projectsLookbooksService
-      .bySlug(slug)
-      .then((lookbooks) => {
-        if (lookbooks.length == 0) {
-          displayNotFound(this.router).then(noop)
-        }
-        return lookbooks
-      })
-  }
-
-  public lookbooks!: Promise<ReadonlyArray<Lookbook>>
+  public lookbooks!: Observable<ReadonlyArray<Lookbook>>
+  protected readonly MAX_SLIDES_PER_VIEW = 3
+  protected readonly MAX_LOOKBOOKS_PER_VIEWPORT = 2
+  protected readonly DEFAULT_IMAGE_ALT = DEFAULT_IMAGE_ALT
 
   constructor(
     private projectsLookbooksService: ProjectLookbooksService,
     private router: Router,
   ) {}
+
+  @Input({ required: true })
+  public set slug(slug: string) {
+    this.lookbooks = this.projectsLookbooksService.bySlug(slug).pipe(
+      map((lookbooksImages) =>
+        lookbooksImages.map((lookbookImages) => ({
+          images: lookbookImages,
+          swiperOptions: this.getSwiperOptions(lookbookImages.length),
+        })),
+      ),
+      tap((lookbooks) => {
+        if (lookbooks.length === 0) {
+          displayNotFound(this.router).then(noop)
+        }
+        return lookbooks
+      }),
+    )
+  }
+
+  private getSwiperOptions(slidesCount: number): SwiperOptions {
+    const loop = slidesCount > this.MAX_SLIDES_PER_VIEW * 2
+    return {
+      pagination: {
+        enabled: true,
+        clickable: true,
+        dynamicBullets: true,
+      },
+      navigation: {
+        enabled: true,
+      },
+      keyboard: {
+        enabled: true,
+      },
+      loop,
+      rewind: !loop,
+      autoplay: {
+        disableOnInteraction: true,
+        delay: 2500,
+      },
+      slidesPerView: 2,
+      breakpoints: {
+        959.98: {
+          slidesPerView: this.MAX_SLIDES_PER_VIEW,
+        },
+      },
+    }
+  }
+}
+
+interface Lookbook {
+  readonly images: ReadonlyArray<ImageAsset>
+  readonly swiperOptions: SwiperOptions
 }

--- a/src/app/projects-page/project-item/project-item.component.html
+++ b/src/app/projects-page/project-item/project-item.component.html
@@ -41,7 +41,7 @@
       sizes="(max-width: 959.98px) 50vw, 33vw"
       [fill]="true"
       [priority]="priorityPreviewImages && i < SLIDES_PER_VIEW"
-      alt="Image"
+      [alt]="image.alt ?? DEFAULT_IMAGE_ALT"
     />
   </swiper-slide>
 </swiper-container>

--- a/src/app/projects-page/project-item/project-item.component.scss
+++ b/src/app/projects-page/project-item/project-item.component.scss
@@ -5,7 +5,6 @@
 @use 'paddings';
 @use 'page';
 @use 'typographies';
-@use 'theme';
 @use 'swiper';
 
 :host {
@@ -25,7 +24,7 @@
     width: $texts-width-big-screen;
   }
 
-  @include swiper.theme(theme.$accent);
+  @include swiper.theme;
 
   swiper-container {
     // 👇 Seems swiper needs size set to work fine

--- a/src/app/projects-page/project-item/project-item.component.ts
+++ b/src/app/projects-page/project-item/project-item.component.ts
@@ -4,6 +4,7 @@ import { SwiperOptions } from 'swiper/types'
 import { ImageAsset } from '../../../data/images/types'
 import { ProjectPreviewImagesService } from './project-preview-images.service'
 import { PROJECTS_PATH } from '../../routes'
+import { DEFAULT_IMAGE_ALT } from '../../common/default-image-alt'
 
 @Component({
   selector: 'app-project-item',
@@ -35,6 +36,8 @@ export class ProjectItemComponent implements OnChanges {
     slidesPerView: this.SLIDES_PER_VIEW,
   }
   public previewImages!: Promise<ReadonlyArray<ImageAsset>>
+  protected readonly PROJECTS_PATH = PROJECTS_PATH
+  protected readonly DEFAULT_IMAGE_ALT = DEFAULT_IMAGE_ALT
 
   constructor(
     private projectPreviewImagesService: ProjectPreviewImagesService,
@@ -43,6 +46,4 @@ export class ProjectItemComponent implements OnChanges {
   ngOnChanges(): void {
     this.previewImages = this.projectPreviewImagesService.bySlug(this.item.slug)
   }
-
-  protected readonly PROJECTS_PATH = PROJECTS_PATH
 }

--- a/src/sass/_anchors.scss
+++ b/src/sass/_anchors.scss
@@ -1,10 +1,11 @@
 @use 'typographies';
 @use 'animations';
+@use 'theme';
 
-@mixin theme($accent-color) {
+@mixin theme {
   // https://css-tricks.com/css-link-hover-effects/#aa-the-growing-background-link-hover-effect
   $color: inherit;
-  $hover-color: $accent-color;
+  $hover-color: theme.$accent;
   a {
     text-decoration: none;
     color: $color;

--- a/src/sass/_swiper.scss
+++ b/src/sass/_swiper.scss
@@ -1,5 +1,7 @@
-@mixin theme($accent) {
-  $balanced-luminance-color: $accent;
+@use 'theme';
+
+@mixin theme() {
+  $balanced-luminance-color: theme.$accent;
 
   swiper-container::part(button-prev) {
     color: $balanced-luminance-color;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -17,4 +17,4 @@ body {
   @include typographies.body-family;
 }
 
-@include anchors.theme(theme.$accent);
+@include anchors.theme;


### PR DESCRIPTION
Renders a swiper for each lookbook in a project's detail view

## Features
- Render a swiper for each lookbok in a project's detail view
- Swiper to loop if enough images, rewind otherwise
- Swiper to take almost all height available
- Image optimization as usual (loading, fetchpriority, srcset, sizes)
- Read `alt` from image asset, or use default value if not defined

## Refactor
- Read accent color from theme directly, easier to change things
