### PR TITLE
build: enable lighthouse for more routes

### DIFF
--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -2,10 +2,15 @@ module.exports = {
   ci: {
     upload: {
       target: 'temporary-public-storage',
-      url: ['http://localhost/'],
     },
     collect: {
+      numberOfRuns: 3,
       staticDistDir: process.env.CI ? '.' : 'dist/chrislb/browser',
+      url: [
+        'http://localhost/',
+        'http://localhost/projects/chiasma/',
+        'http://localhost/404',
+      ],
     },
     assert: {
       preset: 'lighthouse:no-pwa',

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -36,8 +36,10 @@ import { NotFoundPageComponent } from './not-found-page/not-found-page.component
           path: NOT_FOUND_PATH,
           component: NotFoundPageComponent,
           data: {
-            NOT_FOUND_DATA,
-            url: getCanonicalUrlForPath(NOT_FOUND_PATH),
+            NgaoxSeo: {
+              ...NOT_FOUND_DATA.NgaoxSeo,
+              url: getCanonicalUrlForPath(NOT_FOUND_PATH),
+            },
           },
         },
         {

--- a/src/app/logo/logo.component.html
+++ b/src/app/logo/logo.component.html
@@ -7,6 +7,6 @@
     [height]="logoImages.horizontal.height"
     [priority]="true"
     ngSrcset="128w, 256w, 384w, 640w, 750w, 828w, 1080w, 1200w, 1920w, 2048w, 3840w"
-    sizes="100vw"
+    sizes="674px, 92.27vw"
   />
 </a>

--- a/src/app/project-page/lookbooks/lookbook/lookbook.component.html
+++ b/src/app/project-page/lookbooks/lookbook/lookbook.component.html
@@ -15,7 +15,7 @@
     <img
       [ngSrc]="image.filePath"
       ngSrcset="128w, 256w, 384w, 640w, 750w, 828w, 1080w, 1200w, 1920w"
-      sizes="(max-width: 959.98px) 50vw, 33vw"
+      sizes="45vw, 33vw"
       [fill]="true"
       [priority]="priority && imageIndex < MAX_SLIDES_PER_VIEW"
       [alt]="image.alt || DEFAULT_IMAGE_ALT"

--- a/src/app/project-page/lookbooks/lookbook/lookbook.component.html
+++ b/src/app/project-page/lookbooks/lookbook/lookbook.component.html
@@ -12,6 +12,7 @@
   >
     <!-- TODO: a11y -->
     <!-- Keep in sync with breakpoints SCSS. srcset subset from Angular defaults -->
+    <!-- Added 320w to make Lighthouse happy -->
     <img
       [ngSrc]="image.filePath"
       ngSrcset="128w, 256w, 320w, 384w, 640w, 750w, 828w, 1080w, 1200w, 1920w"

--- a/src/app/project-page/lookbooks/lookbook/lookbook.component.html
+++ b/src/app/project-page/lookbooks/lookbook/lookbook.component.html
@@ -14,8 +14,8 @@
     <!-- Keep in sync with breakpoints SCSS. srcset subset from Angular defaults -->
     <img
       [ngSrc]="image.filePath"
-      ngSrcset="128w, 256w, 384w, 640w, 750w, 828w, 1080w, 1200w, 1920w"
-      sizes="45vw, 33vw"
+      ngSrcset="128w, 256w, 320w, 384w, 640w, 750w, 828w, 1080w, 1200w, 1920w"
+      sizes="calc(50vw - 16px), 33.33vw"
       [fill]="true"
       [priority]="priority && imageIndex < MAX_SLIDES_PER_VIEW"
       [alt]="image.alt || DEFAULT_IMAGE_ALT"

--- a/src/app/project-page/project-page.component.ts
+++ b/src/app/project-page/project-page.component.ts
@@ -1,10 +1,34 @@
-import { Component, Input } from '@angular/core'
+import { Component, Input, OnInit } from '@angular/core'
+import { ProjectsService } from '../projects-page/projects.service'
+import { displayNotFound } from '../common/navigation'
+import { Router } from '@angular/router'
+import { noop } from 'rxjs'
+import { SeoService } from '@ngaox/seo'
+import { getCanonicalUrlForPath, getTitle, PROJECTS_PATH } from '../routes'
 
 @Component({
   selector: 'app-project-page',
   templateUrl: './project-page.component.html',
   styleUrls: ['./project-page.component.scss'],
 })
-export class ProjectPageComponent {
+export class ProjectPageComponent implements OnInit {
   @Input({ required: true }) public slug!: string
+
+  constructor(
+    private projectsService: ProjectsService,
+    private router: Router,
+    private seo: SeoService,
+  ) {}
+
+  ngOnInit(): void {
+    this.projectsService.bySlug(this.slug).then((projectItem) => {
+      this.seo.setUrl(getCanonicalUrlForPath(PROJECTS_PATH, this.slug))
+      if (!projectItem) {
+        displayNotFound(this.router).then(noop)
+        return
+      }
+      this.seo.setTitle(getTitle(projectItem.title))
+      this.seo.setDescription(projectItem.description.join('. '))
+    })
+  }
 }

--- a/src/app/projects-page/projects.service.ts
+++ b/src/app/projects-page/projects.service.ts
@@ -11,6 +11,10 @@ export class ProjectsService {
   async getProjects(): Promise<ReadonlyArray<ProjectItem>> {
     return this.projectsJson
   }
+
+  async bySlug(slug: string): Promise<ProjectItem | null> {
+    return this.projectsJson.find((project) => project.slug === slug) ?? null
+  }
 }
 
 const PROJECTS_JSON = new InjectionToken<JsonProjects>('Projects JSON', {

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -12,10 +12,10 @@ export const NOT_FOUND_DATA: RouteData = {
 export const NOT_FOUND_PATH = '404'
 type RouteData = { NgaoxSeo?: IPageSeoData }
 
-export function getCanonicalUrlForPath(path: string) {
-  return new URL(path, new URL(meta.default.canonicalUrl)).toString()
+export function getCanonicalUrlForPath(...paths: ReadonlyArray<string>) {
+  return new URL(paths.join('/'), new URL(meta.default.canonicalUrl)).toString()
 }
 
-function getTitle(title: string) {
+export function getTitle(title: string) {
   return `${title} | ${meta.default.siteName}`
 }


### PR DESCRIPTION
Enables Lighthouse for more web routes:
- Home page
- Project detail page
- 404 page

💡 `routes-file.txt` containing prerendered routes could be the source of truth of routes to test in Lighthouse

Though when we start adding more prerendered detail pages maybe we need to do some kind of reduction. We don't need to test all detail pages.

## Metadata
Added metadata for project detail view and fixed 404 page one (url)

## Properly size images
https://developer.chrome.com/en/docs/lighthouse/performance/uses-responsive-images/

Failed multiple times for project detail view. 

Tried [`RespImageLint`](https://ausi.github.io/respimagelint/) but prefer to avoid long `sizes`. Also Safari doesn't support the `max-*` in there according to Can I Use.

Tried using `calc(50vw-16px)` to take into account padding. No result

It's weird cause sometimes appears in the web HTML report as passing, but the CLI (and Lighthouse GitHub app) reports a failure. Sometimes it appears as warning.

