### PR TITLE
perf: add Lighthouse exception for non composited animations

### DIFF
--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -15,6 +15,10 @@ module.exports = {
     assert: {
       preset: 'lighthouse:no-pwa',
       assertions: {
+        // 👇 Probably Swiper.js 😭
+        // Just happens on project detail page tho, when many swipers in there
+        // Maybe a grid would solve it
+        'non-composited-animations': 'warn',
         'bf-cache': 'warn',
         'csp-xss': 'warn',
         'unused-javascript': 'warn',


### PR DESCRIPTION
Random failures about `non-composited-animations` have been happening:
https://github.com/davidlj95/chrislb/actions/runs/6661094801/job/18104767063?pr=35

For the project detail view only though. Started happening in #27.
Probably because too many swipers in one page??

Anyway, disabling for now. But should be taken into account, Chrome has collapsed in my laptop when opening that page :')
