### PR TITLE
feat: add decap CMS

### DIFF
--- a/.idea/jsLibraryMappings.xml
+++ b/.idea/jsLibraryMappings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaScriptLibraryMappings">
+    <file url="PROJECT" libraries="{decap-cms}" />
+  </component>
+</project>

--- a/angular.json
+++ b/angular.json
@@ -34,6 +34,7 @@
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
             "assets": [
+              "src/admin",
               "src/apple-touch-icon.png",
               "src/apple-touch-icon-precomposed.png",
               "src/assets",
@@ -101,6 +102,7 @@
             "tsConfig": "tsconfig.spec.json",
             "inlineStyleLanguage": "scss",
             "assets": [
+              "src/admin",
               "src/apple-touch-icon.png",
               "src/apple-touch-icon-precomposed.png",
               "src/assets",

--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -1,0 +1,112 @@
+backend:
+  name: github
+  repo: davidlj95/chrislb
+  branch: main
+publish_mode: editorial_workflow
+media_folder: 'src/assets/cms'
+site_url: https://christianlazaro.es
+display_url: https://github.com/davidlj95/chrislb
+logo_url: https://christianlazaro.es/favicon.svg
+slug:
+  encoding: 'ascii'
+  clean_accents: true
+  sanitize_replacement: '-'
+collections:
+  - name: 'metadata'
+    label: 'Metadata'
+    files:
+      - label: 'Default'
+        name: 'default'
+        file: 'src/data/meta.json'
+        fields:
+          - label: 'Site name'
+            name: 'siteName'
+            widget: 'string'
+            hint: 'This will appear in page titles in browser tabs / windows. Including the page title. Something like: "<Page title> - <Site name>". For instance: "About | Christian Lazaro"'
+            pattern: ['.{1,}', 'Must have at least 1 character']
+          - label: 'Author'
+            name: 'author'
+            widget: 'string'
+            pattern: ['.{1,}', 'Must have at least 1 character']
+          - label: 'Canonical URL'
+            name: 'canonicalUrl'
+            widget: 'string'
+            pattern: ['^https:\/\/.*', 'Must start with https://']
+  - name: 'pages'
+    label: 'Pages'
+    label_singular: 'Page'
+    folder: 'src/data/pages'
+    extension: 'json'
+    create: false
+    delete: false
+    slug: '{{slug}}'
+    editor:
+      preview: false
+    identifier_field: 'slug'
+    preview_path: '{{slug}}'
+    fields:
+      - label: 'Name'
+        name: 'name'
+        widget: 'string'
+        pattern: ['.{1,}', 'Must have at least 1 character']
+        hint: 'Identifies the page in the content manager. But nothing a visitor would see'
+      - label: 'Slug'
+        name: 'slug'
+        widget: 'string'
+        pattern:
+          [
+            '^[a-z0-9-]+$',
+            'Must have at least 1 character and only contain lowercase alphabetic characters, numbers and hyphens (-)',
+          ]
+        hint: '⚠️ Avoid updating without notifying developer :) Sets the page path in the URL. And the filename containing this configuration'
+      - label: 'Title'
+        name: 'title'
+        widget: 'string'
+        hint: 'This will appear in page titles in browser tabs / windows. Including the site name. Something like: "<Page title> - <Site name>". For instance: "About | Christian Lazaro". Leave it empty to show site name only'
+      - label: 'Description'
+        name: 'description'
+        widget: 'string'
+        pattern: ['.{1,}', 'Must have at least 1 character']
+      - label: 'Keywords'
+        name: 'keywords'
+        widget: 'list'
+        summary: '{{fields.keyword}}'
+        required: false
+        field:
+          label: 'Keyword'
+          name: 'keyword'
+          widget: 'string'
+          pattern: ['.{1,}', 'Must have at least 1 character']
+      - label: 'Image'
+        name: 'image'
+        widget: 'object'
+        required: false
+        fields:
+          - label: 'URL'
+            name: 'url'
+            widget: 'string'
+            pattern: ['^https:\/\/.*', 'Must start with https://']
+          - label: 'Alternative text'
+            name: 'alt'
+            widget: 'string'
+            pattern: ['.{1,}', 'Must have at least 1 character']
+          - label: 'Width'
+            name: 'width'
+            widget: 'number'
+            value_type: 'int'
+            min: 256
+          - label: 'Height'
+            name: 'height'
+            widget: 'number'
+            value_type: 'int'
+            min: 256
+          - label: 'MIME Type'
+            name: 'mimeType'
+            widget: 'select'
+            options:
+              - label: 'PNG'
+                value: 'image/png'
+              - label: 'JPG / JPEG'
+                value: 'image/jpeg'
+              - label: 'SVG'
+                value: 'image/svg+xml'

--- a/src/admin/index.html
+++ b/src/admin/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="noindex" />
+    <title>Content Manager</title>
+  </head>
+  <body>
+    <!-- Include the script that builds the page and powers Decap CMS -->
+    <script src="https://unpkg.com/decap-cms@^3.0.0/dist/decap-cms.js"></script>
+  </body>
+</html>

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -27,6 +27,10 @@ import notFoundPageMetadata from '../data/pages/not-found.json'
           component: ProjectPageComponent,
         },
         {
+          path: PROJECTS_PATH,
+          redirectTo: '/',
+        },
+        {
           path: NOT_FOUND_PATH,
           component: NotFoundPageComponent,
           data: makeRouteMetadadata(notFoundPageMetadata, NOT_FOUND_PATH),

--- a/src/app/routes.ts
+++ b/src/app/routes.ts
@@ -1,8 +1,10 @@
 import { IPageSeoData } from '@ngaox/seo'
 import meta from '../data/meta.json'
+import notFoundPage from '../data/pages/not-found.json'
+import projectsPage from '../data/pages/projects.json'
 
-export const PROJECTS_PATH = 'projects'
-export const NOT_FOUND_PATH = '404'
+export const PROJECTS_PATH = projectsPage.slug
+export const NOT_FOUND_PATH = notFoundPage.slug
 
 type RouteData = {
   NgaoxSeo?: IPageSeoData

--- a/src/data/pages/not-found.json
+++ b/src/data/pages/not-found.json
@@ -1,5 +1,6 @@
 {
   "name": "Not Found",
+  "slug": "404",
   "title": "Not Found",
   "description": "The requested content could not be found"
 }

--- a/src/data/pages/projects.json
+++ b/src/data/pages/projects.json
@@ -1,5 +1,6 @@
 {
   "name": "Projects",
+  "slug": "projects",
   "title": "",
   "description": "Fashion designer and stylist, @christian_labu",
   "keywords": [


### PR DESCRIPTION
Adds [Decap CMS](https://decapcms.org/) to the site, so contents can be edited by non-dev users

URL: `/admin` (either in localhost, prod, ...)

Adds also configuration to edit site's metadata and pages metadata

Refactors to use `slug` as path for the page (so it can be used as preview path too)

Redirects `/projects` to `/` so preview path works for projects page too.