### PR TITLE
feat(cms): fix and improve deploy links

### DIFF
--- a/.github/actions/deploy-preview-status/action.yml
+++ b/.github/actions/deploy-preview-status/action.yml
@@ -1,0 +1,33 @@
+name: Deploy preview status
+description: Sets a GitHub status for the given commit to notify about deploy preview. So Decap CMS can read it.
+inputs:
+  state:
+    # https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#create-a-commit-status
+    description: 'State to set to the status to'
+    required: true
+  url:
+    description: 'URL containing the deploy preview'
+    required: false
+runs:
+  using: 'composite'
+  steps:
+    - name: Set deploy status
+      if: github.event_name == 'pull_request'
+      uses: actions/github-script@v6
+      env:
+        # 👇 To be in sync with Decap CMS config
+        STATUS_CONTEXT: 'deploy/preview'
+      with:
+        retries: 3
+        script: |
+          const result = await github.rest.repos.createCommitStatus({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            // 👇 context.sha refers to merge branch SHA
+            sha: context.payload.pull_request.head.sha,
+            state: '${{ inputs.state }}',
+            description: 'Deploy preview (to notify Decap CMS)',
+            context: '${{ env.STATUS_CONTEXT }}',
+            target_url: '${{ inputs.url }}' || undefined
+          });
+          console.log(result);

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,6 +9,7 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     permissions:
       contents: write
+      statuses: write
     with:
       artifact-name: build
   test:

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -11,6 +11,10 @@ on:
         required: false
         default: ''
 
+permissions:
+  # 👇 For Decap CMS commit status
+  statuses: write
+
 jobs:
   build:
     name: Build and prerender app
@@ -21,6 +25,10 @@ jobs:
         uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
         with:
           ref: ${{ inputs.ref }}
+      - name: Notify deploy preview will come
+        uses: ./.github/actions/deploy-preview-status
+        with:
+          state: 'pending'
       - name: Setup
         uses: ./.github/actions/setup
       - name: Cache Angular build

--- a/.github/workflows/reusable-deploy-cloudflare-pages.yml
+++ b/.github/workflows/reusable-deploy-cloudflare-pages.yml
@@ -71,22 +71,10 @@ jobs:
           directory: '.'
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
       # 👇 Needed for Decap CMS. It will read this status to create the preview URL
-      - name: Set deploy status
-        if: github.event_name == 'pull_request'
-        uses: actions/github-script@v6
-        env:
-          # 👇 To be in sync with Decap CMS config
-          STATUS_CONTEXT: 'deploy/preview'
+      - name: Checkout
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+      - name: Deploy preview status
+        uses: ./.github/actions/deploy-preview-status
         with:
-          retries: 3
-          script: |
-            const result = await github.rest.repos.createCommitStatus({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              sha: context.sha,
-              state: 'success',
-              description: 'Deploy preview',
-              context: '${{ env.STATUS_CONTEXT }}',
-              target_url: '${{ steps.deploy.outputs.url }}'
-            });
-            console.log(result);
+          state: 'success'
+          url: ${{ steps.deploy.outputs.url }}

--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -16,6 +16,8 @@ slug:
   encoding: 'ascii'
   clean_accents: true
   sanitize_replacement: '-'
+editor:
+  preview: false
 collections:
   - name: 'metadata'
     label: 'Metadata'

--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -5,6 +5,7 @@ backend:
   # 👇 To be in sync with Cloudflare Pages deploy previews
   preview_context: 'deploy/preview'
   cms_label_prefix: decap-cms/
+  squash_merges: true
 publish_mode: editorial_workflow
 media_folder: 'src/assets/cms'
 public_folder: '/assets/cms'


### PR DESCRIPTION
Fixes deploy status creation. Status was created for merge branch SHA instead of head branch SHA. Tested in #51

Refactors to use a composite action.

Calls the action from build job too, so we notify as early as possible that a preview is coming.

Bonus: squash merge + disable preview panes globally