### PR TITLE
feat(cms): add config to manage projects data

### DIFF
--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -153,7 +153,7 @@ collections:
         required: false
       - label: 'Description'
         name: 'description'
-        widget: 'markdown'
+        widget: 'text'
       - label: 'Credits'
         name: 'credits'
         widget: 'list'

--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -48,6 +48,8 @@ collections:
             pattern: ['^https:\/\/.*', 'Must start with https://']
   - name: 'pages'
     label: 'Pages'
+    # 👇 Apparently only used in commit messages / PR titles
+    # So lowercase is better for those contexts
     label_singular: 'page'
     folder: 'src/data/pages'
     extension: 'json'
@@ -128,6 +130,7 @@ collections:
     create: true
     slug: '{{fields.slug}}'
     identifier_field: 'slug'
+    summary: '{{title}}'
     fields:
       - label: 'Slug'
         name: 'slug'

--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -48,7 +48,7 @@ collections:
             pattern: ['^https:\/\/.*', 'Must start with https://']
   - name: 'pages'
     label: 'Pages'
-    label_singular: 'Page'
+    label_singular: 'page'
     folder: 'src/data/pages'
     extension: 'json'
     create: false
@@ -120,3 +120,49 @@ collections:
                 value: 'image/jpeg'
               - label: 'SVG'
                 value: 'image/svg+xml'
+  - name: 'projects'
+    label: 'Projects'
+    label_singular: 'project'
+    folder: 'src/data/projects'
+    extension: 'json'
+    create: true
+    slug: '{{fields.slug}}'
+    identifier_field: 'slug'
+    fields:
+      - label: 'Slug'
+        name: 'slug'
+        widget: 'string'
+        pattern:
+          [
+            '^[a-z0-9-]+$',
+            'Must have at least 1 character and only contain lowercase alphabetic characters, numbers and hyphens (-)',
+          ]
+        hint: '⚠️ Avoid updating CHIASMA one without notifying developer :) Sets the project path in the URL. Use it in the image CDN as directory name to include images for this project.'
+      - label: 'Title'
+        name: 'title'
+        widget: 'string'
+      - label: 'Subtitle'
+        name: 'subtitle'
+        widget: 'string'
+      - label: 'Quote'
+        name: 'quote'
+        widget: 'string'
+        required: false
+      - label: 'Description'
+        name: 'description'
+        widget: 'markdown'
+      - label: 'Credits'
+        name: 'credits'
+        widget: 'list'
+        required: false
+        fields:
+          - label: 'Name'
+            name: 'name'
+            widget: 'string'
+          - label: 'Role'
+            name: 'role'
+            widget: 'string'
+          - label: 'Nickname'
+            name: 'nickname'
+            widget: 'string'
+            hint: 'Without the @. Links to instagram profile'


### PR DESCRIPTION
Add projects configuration in Decap CMS

Summary is title field

Description field set to text + with #62 line breaks are kept visually

Also rename singular labels to use lowercase. Given they seem to be used only for commit messages and PR titles so lowercase fits better then.