### PR TITLE
refactor: move project files (again) to prepare for CMS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -376,7 +376,7 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/angular,vim,visualstudiocode,node,webstorm+iml,macos,linux,windows,lighthouseci,dotenv
-src/data/projects/list.json
+src/data/projects-list.json
 # Manual edit
 # - Remove .idea from Angular. We want some IDE settings!
 # - Add generated list.json

--- a/scripts/src/generate-data.mts
+++ b/scripts/src/generate-data.mts
@@ -4,37 +4,29 @@ import { readdir, readFile, writeFile } from 'fs/promises'
 import { getRepositoryRootDir } from './get-repository-root-dir.mjs'
 import path from 'path'
 
-const PROJECTS_DIR = path.join(
-  getRepositoryRootDir(),
-  'src',
-  'data',
-  'projects',
-)
-const JSON_DATA_FILENAME = 'data.json'
-const LIST_JSON_FILENAME = 'list.json'
+const DATA_DIR = path.join(getRepositoryRootDir(), 'src', 'data')
+const PROJECTS_DIR = path.join(DATA_DIR, 'projects')
+const LIST_JSON_FILE_PATH = path.join(DATA_DIR, 'projects-list.json')
 
 async function generateData() {
-  const projectDirectories = (
+  const projectJsonFiles = (
     await readdir(PROJECTS_DIR, { withFileTypes: true })
-  ).filter((dirent) => dirent.isDirectory())
-  Log.info('Found %d project directories', projectDirectories.length)
-  projectDirectories.forEach((projectDirectory) =>
+  ).filter((dirent) => dirent.isFile() && dirent.name.endsWith('json'))
+  Log.info('Found %d project JSON files', projectJsonFiles.length)
+  projectJsonFiles.forEach((projectDirectory) =>
     Log.item(projectDirectory.name),
   )
-  Log.info('Reading data from each project directory')
-  const dataJsons = await Promise.all(
-    projectDirectories.map(async (projectDirectory) => {
-      Log.item(projectDirectory.name)
-      const jsonData = await readFile(
-        path.join(PROJECTS_DIR, projectDirectory.name, JSON_DATA_FILENAME),
+  Log.info('Reading data from each file')
+  const projectsJsons = await Promise.all(
+    projectJsonFiles.map(async (projectJsonFile) => {
+      Log.item(projectJsonFile.name)
+      const buffer = await readFile(
+        path.join(PROJECTS_DIR, projectJsonFile.name),
       )
-      return JSON.parse(jsonData.toString())
+      return JSON.parse(buffer.toString())
     }),
   )
-  await writeFile(
-    path.join(PROJECTS_DIR, LIST_JSON_FILENAME),
-    JSON.stringify(dataJsons, null, 2),
-  )
+  await writeFile(LIST_JSON_FILE_PATH, JSON.stringify(projectsJsons, null, 2))
 }
 
 if (isMain(import.meta.url)) {

--- a/src/app/projects-page/project-item/project-item.component.html
+++ b/src/app/projects-page/project-item/project-item.component.html
@@ -1,11 +1,9 @@
 <div class="text-and-images">
   <div class="texts">
     <span class="title">
-      <ng-container *ngIf="item.hasDetails">
-        <a [routerLink]="[PROJECTS_PATH, item.slug]"
-          ><ng-container [ngTemplateOutlet]="title"></ng-container
-        ></a>
-      </ng-container>
+      <a [routerLink]="[PROJECTS_PATH, item.slug]"
+        ><ng-container [ngTemplateOutlet]="title"></ng-container
+      ></a>
       <ng-template #title>
         {{ item.title }}
       </ng-template>

--- a/src/app/projects-page/project-item/project-item.ts
+++ b/src/app/projects-page/project-item/project-item.ts
@@ -5,7 +5,6 @@ export interface ProjectItem {
   readonly quote?: string
   readonly description: readonly string[]
   readonly credits: readonly Credit[]
-  readonly hasDetails: boolean
 }
 
 export interface Credit {

--- a/src/app/projects-page/projects.service.ts
+++ b/src/app/projects-page/projects.service.ts
@@ -1,5 +1,5 @@
 import { Inject, Injectable, InjectionToken } from '@angular/core'
-import projectsList from '../../data/projects/list.json'
+import projectsList from '../../data/projects-list.json'
 import { ProjectItem } from './project-item/project-item'
 
 @Injectable({

--- a/src/data/projects/chiasma.json
+++ b/src/data/projects/chiasma.json
@@ -18,6 +18,5 @@
       "name": "Alejandro Flama",
       "nickname": "flama.ph"
     }
-  ],
-  "hasDetails": true
+  ]
 }


### PR DESCRIPTION
After testing, seems Decap can't manage a collections directory whose entries are located in a directory with their slug. So simplifying by just adding a file with the slug.

Move list out of the directory to avoid conflicts.

Remove temporarily `hasDetails` field to simplify. Will add it later
