### PR TITLE
ci: fix permissions issue with deploy preview workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,3 +57,5 @@ jobs:
     permissions:
       contents: read
       deployments: write
+      #👇 For Decap CMS
+      statuses: write

--- a/.github/workflows/reusable-deploy-cloudflare-pages.yml
+++ b/.github/workflows/reusable-deploy-cloudflare-pages.yml
@@ -16,7 +16,7 @@ permissions:
   contents: read
   deployments: write
   # 👇 For Decap CMS commit status. PRs only
-  # statuses: write
+  statuses: write
 
 concurrency:
   group: cloudflare-pages-${{ github.ref }}


### PR DESCRIPTION
Workflows started failing recently:
https://github.com/davidlj95/chrislb/actions/runs/6679681677/job/18152026250?pr=57

Error is deploy preview workflow can't write the commit status.

Probably because permission request in the workflow was removed, cause in main workflow the permission is not needed:
https://github.com/davidlj95/chrislb/commit/6f699a27f2f399beca1561979e66505e2f2ef7a5

But seems if it doesn't request it, despite granted, doesn't work

So requesting it again. And granting it in main workflow despite not using it.

Quirk: the pending commit status can be created despite not requesting the permission in the build step. But if removing the permission grant in the pull request workflow, doesn't work.
