### PR TITLE
feat(authors): add author entity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -376,7 +376,7 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/angular,vim,visualstudiocode,node,webstorm+iml,macos,linux,windows,lighthouseci,dotenv
-src/data/projects-list.json
+src/data/*-list.json
 # Manual edit
 # - Remove .idea from Angular. We want some IDE settings!
-# - Add generated list.json
+# - Add generated JSON lists

--- a/.idea/runConfigurations/CMS_Server.xml
+++ b/.idea/runConfigurations/CMS_Server.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="CMS Server" type="js.build_tools.npm">
+    <package-json value="$PROJECT_DIR$/package.json" />
+    <command value="run" />
+    <scripts>
+      <script value="cms-server" />
+    </scripts>
+    <node-interpreter value="project" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/README.md
+++ b/README.md
@@ -67,3 +67,25 @@ To do so, install the hooks by running
 ```shell
 npm run git-hooks
 ```
+
+## CMS
+
+Contents can be edited easily thanks to a CMS. That CMS is [Decap CMS] (formerly known as Netlify CMS). To access it, just access the `/admin/` path.
+
+Production: https://christianlazaro.es/admin/
+
+Push access to the repo is needed, given the CMS will create pull requests with content changes.
+
+### Locally
+
+To work locally, add uncomment the `local_backend: true` line in the configuration.
+
+Then, run the local server:
+
+```
+npm run cms-server
+```
+
+> ⚠️ Do not commit the local backend configuration to main branch
+
+[Decap CMS]: https://decapcms.org

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "lint-staged": "lint-staged",
     "git-hooks": "husky install",
     "generate-prettierignore": "cp .gitignore .prettierignore && cat .part.prettierignore >> .prettierignore",
-    "generate-data": "ts-node scripts/src/generate-data.mts"
+    "generate-data": "ts-node scripts/src/generate-data.mts",
+    "cms-server": "npx decap-server"
   },
   "private": true,
   "dependencies": {

--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -169,3 +169,29 @@ collections:
             name: 'nickname'
             widget: 'string'
             hint: 'Without the @. Links to instagram profile'
+  - name: 'authors'
+    label: 'Authors'
+    label_singular: 'author'
+    folder: 'src/data/authors'
+    extension: 'json'
+    create: true
+    slug: '{{slug}}'
+    identifier_field: 'name'
+    summary: '{{name}}'
+    fields:
+      - label: 'Name'
+        name: 'name'
+        widget: 'string'
+      - label: 'Social'
+        name: 'social'
+        widget: 'object'
+        fields:
+          - label: 'Instagram'
+            name: 'instagram'
+            widget: 'string'
+            pattern:
+              [
+                '^[^@]*+',
+                'Must have at least 1 character. Must not start with @ (will be added automagically 🪄)',
+              ]
+            hint: 'Links to instagram profile. Without the @ at the beginning'

--- a/src/data/authors/alejandro-flama.json
+++ b/src/data/authors/alejandro-flama.json
@@ -1,0 +1,6 @@
+{
+  "name": "Alejandro Flama",
+  "social": {
+    "instagram": "flama.ph"
+  }
+}

--- a/src/data/authors/christian-lazaro.json
+++ b/src/data/authors/christian-lazaro.json
@@ -1,0 +1,6 @@
+{
+  "name": "Christian Lazaro",
+  "social": {
+    "instagram": "christian_labu"
+  }
+}

--- a/src/data/projects/chiasma.json
+++ b/src/data/projects/chiasma.json
@@ -7,11 +7,13 @@
   "credits": [
     {
       "role": "Designer, Creative Director",
+      "slug": "christian-lazaro",
       "name": "Christian Lázaro",
       "nickname": "christian_labu"
     },
     {
       "role": "Photographer",
+      "slug": "alejandro-flama",
       "name": "Alejandro Flama",
       "nickname": "flama.ph"
     }


### PR DESCRIPTION
Adds an author model to be able to link them to project credits. So if we change details of an author, details are changed for all projects.

- Add author directory and JSONs
- Configure author to be editable from CMS
- Add docs to run CMS locally
- Ignore all lists in gitignore
- Aggregate authors using generation script
- Refactor generation script for generic list files generation
- Link chiasma credits to the just created authors