### PR TITLE
feat(projects): use authors for credits

### DIFF
--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -1,4 +1,3 @@
-local_backend: true
 backend:
   name: github
   repo: davidlj95/chrislb

--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -1,3 +1,4 @@
+local_backend: true
 backend:
   name: github
   repo: davidlj95/chrislb
@@ -157,18 +158,19 @@ collections:
       - label: 'Credits'
         name: 'credits'
         widget: 'list'
+        summary: '{{fields.role}}: {{fields.authorSlug}}'
         required: false
         fields:
-          - label: 'Name'
-            name: 'name'
-            widget: 'string'
           - label: 'Role'
             name: 'role'
             widget: 'string'
-          - label: 'Nickname'
-            name: 'nickname'
-            widget: 'string'
-            hint: 'Without the @. Links to instagram profile'
+          - label: 'Author'
+            name: 'authorSlug'
+            widget: 'relation'
+            collection: 'authors'
+            search_fields: ['name', 'social.instagram']
+            value_field: '{{slug}}'
+            display_fields: ['{{name}} ({{social.instagram}})']
   - name: 'authors'
     label: 'Authors'
     label_singular: 'author'

--- a/src/app/common/authors.service.spec.ts
+++ b/src/app/common/authors.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing'
+
+import { AuthorsService } from './authors.service'
+
+describe('AuthorsService', () => {
+  let service: AuthorsService
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({})
+    service = TestBed.inject(AuthorsService)
+  })
+
+  it('should be created', () => {
+    expect(service).toBeTruthy()
+  })
+})

--- a/src/app/common/authors.service.ts
+++ b/src/app/common/authors.service.ts
@@ -1,0 +1,25 @@
+import { Inject, Injectable, InjectionToken } from '@angular/core'
+import authorsList from '../../data/authors-list.json'
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AuthorsService {
+  private authorBySlug: Map<string, Author>
+
+  constructor(@Inject(AUTHORS_JSON) authorsJson: Authors) {
+    this.authorBySlug = new Map(
+      authorsJson.map((author) => [author.slug, author]),
+    )
+  }
+
+  public bySlug(slug: string): Author | undefined {
+    return this.authorBySlug.get(slug)
+  }
+}
+
+export const AUTHORS_JSON = new InjectionToken('Authors list JSON', {
+  factory: () => authorsList,
+})
+export type Authors = typeof authorsList
+export type Author = Authors[number]

--- a/src/app/projects-page/project-item/project-item.component.html
+++ b/src/app/projects-page/project-item/project-item.component.html
@@ -1,18 +1,18 @@
 <div class="text-and-images">
   <div class="texts">
     <span class="title">
-      <a [routerLink]="[PROJECTS_PATH, item.slug]"
+      <a [routerLink]="[PROJECTS_PATH, _item.slug]"
         ><ng-container [ngTemplateOutlet]="title"></ng-container
       ></a>
       <ng-template #title>
-        {{ item.title }}
+        {{ _item.title }}
       </ng-template>
     </span>
     <span class="subtitle">
-      {{ item.subtitle }}
+      {{ _item.subtitle }}
     </span>
-    <span class="quote" *ngIf="item.quote"> "{{ item.quote }}" </span>
-    <div class="description" [innerHtml]="item.description"></div>
+    <span class="quote" *ngIf="_item.quote"> "{{ _item.quote }}" </span>
+    <div class="description" [innerHtml]="_item.description"></div>
   </div>
   <app-image-swiper
     [images]="previewImages | async"
@@ -22,13 +22,17 @@
     [customSwiperOptions]="CUSTOM_SWIPER_OPTIONS"
   ></app-image-swiper>
 </div>
-<div class="credits" *ngIf="item.credits.length">
-  <span *ngFor="let credit of item.credits">
-    {{ credit.role }}: {{ credit.name }}
-    <span class="anchor"
-      >(<a href="https://instagram.com/_u/{{ credit.nickname }}" target="_blank"
-        >@{{ credit.nickname }}</a
-      >)</span
-    >
-  </span>
+<div class="credits" *ngIf="credits.length">
+  <ng-container *ngFor="let credit of credits">
+    <span *ngIf="credit.author">
+      {{ credit.role }}: {{ credit.author.name }}
+      <span class="anchor"
+        >(<a
+          href="https://instagram.com/_u/{{ credit.author.social.instagram }}"
+          target="_blank"
+          >@{{ credit.author.social.instagram }}</a
+        >)</span
+      >
+    </span>
+  </ng-container>
 </div>

--- a/src/app/projects-page/project-item/project-item.component.ts
+++ b/src/app/projects-page/project-item/project-item.component.ts
@@ -1,18 +1,29 @@
-import { Component, Input, OnChanges } from '@angular/core'
-import { ProjectItem } from './project-item'
+import { Component, Input } from '@angular/core'
+import { Credit, ProjectItem } from './project-item'
 import { SwiperOptions } from 'swiper/types'
 import { ImageAsset } from '../../../data/images/types'
 import { ProjectPreviewImagesService } from './project-preview-images.service'
 import { PROJECTS_PATH } from '../../routes'
 import { ImageResponsiveBreakpointsService } from '../../common/image-responsive-breakpoints.service'
+import { Author, AuthorsService } from '../../common/authors.service'
 
 @Component({
   selector: 'app-project-item',
   templateUrl: './project-item.component.html',
   styleUrls: ['./project-item.component.scss'],
 })
-export class ProjectItemComponent implements OnChanges {
-  @Input({ required: true }) public item!: ProjectItem
+export class ProjectItemComponent {
+  protected _item!: ProjectItem
+  @Input({ required: true })
+  public set item(item: ProjectItem) {
+    this._item = item
+    this.previewImages = this.projectPreviewImagesService.bySlug(item.slug)
+    this.credits = item.credits.map((credit) => ({
+      ...credit,
+      author: this.authorsService.bySlug(credit.slug),
+    }))
+  }
+
   @Input() public priority?: boolean
   public readonly CUSTOM_SWIPER_OPTIONS: SwiperOptions = {
     slidesPerView: 2,
@@ -24,14 +35,16 @@ export class ProjectItemComponent implements OnChanges {
       this.imageResponsiveBreakpointsService.MAX_SCREEN_WIDTH_PX / 3,
     )
     .toSrcSet()
+  public credits!: ReadonlyArray<CreditItem>
   protected readonly PROJECTS_PATH = PROJECTS_PATH
 
   constructor(
     private projectPreviewImagesService: ProjectPreviewImagesService,
     private imageResponsiveBreakpointsService: ImageResponsiveBreakpointsService,
+    private authorsService: AuthorsService,
   ) {}
+}
 
-  ngOnChanges(): void {
-    this.previewImages = this.projectPreviewImagesService.bySlug(this.item.slug)
-  }
+type CreditItem = Omit<Credit, 'slug'> & {
+  author: Author | undefined
 }

--- a/src/app/projects-page/project-item/project-item.component.ts
+++ b/src/app/projects-page/project-item/project-item.component.ts
@@ -20,7 +20,7 @@ export class ProjectItemComponent {
     this.previewImages = this.projectPreviewImagesService.bySlug(item.slug)
     this.credits = item.credits.map((credit) => ({
       ...credit,
-      author: this.authorsService.bySlug(credit.slug),
+      author: this.authorsService.bySlug(credit.authorSlug),
     }))
   }
 
@@ -45,6 +45,6 @@ export class ProjectItemComponent {
   ) {}
 }
 
-type CreditItem = Omit<Credit, 'slug'> & {
+type CreditItem = Omit<Credit, 'authorSlug'> & {
   author: Author | undefined
 }

--- a/src/app/projects-page/project-item/project-item.ts
+++ b/src/app/projects-page/project-item/project-item.ts
@@ -11,5 +11,5 @@ export interface Credit {
   readonly role: string
   readonly name: string
   readonly nickname: string
-  readonly slug: string
+  readonly authorSlug: string
 }

--- a/src/app/projects-page/project-item/project-item.ts
+++ b/src/app/projects-page/project-item/project-item.ts
@@ -9,7 +9,5 @@ export interface ProjectItem {
 
 export interface Credit {
   readonly role: string
-  readonly name: string
-  readonly nickname: string
   readonly authorSlug: string
 }

--- a/src/app/projects-page/project-item/project-item.ts
+++ b/src/app/projects-page/project-item/project-item.ts
@@ -11,4 +11,5 @@ export interface Credit {
   readonly role: string
   readonly name: string
   readonly nickname: string
+  readonly slug: string
 }

--- a/src/data/projects/chiasma.json
+++ b/src/data/projects/chiasma.json
@@ -7,15 +7,11 @@
   "credits": [
     {
       "role": "Designer, Creative Director",
-      "authorSlug": "christian-lazaro",
-      "name": "Christian Lázaro",
-      "nickname": "christian_labu"
+      "authorSlug": "christian-lazaro"
     },
     {
       "role": "Photographer",
-      "authorSlug": "alejandro-flama",
-      "name": "Alejandro Flama",
-      "nickname": "flama.ph"
+      "authorSlug": "alejandro-flama"
     }
   ]
 }

--- a/src/data/projects/chiasma.json
+++ b/src/data/projects/chiasma.json
@@ -7,13 +7,13 @@
   "credits": [
     {
       "role": "Designer, Creative Director",
-      "slug": "christian-lazaro",
+      "authorSlug": "christian-lazaro",
       "name": "Christian Lázaro",
       "nickname": "christian_labu"
     },
     {
       "role": "Photographer",
-      "slug": "alejandro-flama",
+      "authorSlug": "alejandro-flama",
       "name": "Alejandro Flama",
       "nickname": "flama.ph"
     }


### PR DESCRIPTION
Use author slug in credits to link credits to authors.

Add authors service to be able to retrieve an author given its slug.

Replace `OnChanges` by an item setter (to better reflect everything depends on the item set)

`slug` to `authorSlug` in credits for explicitness

Remove `name` and `nickname` from credits

Configure CMS to link credit to author