### PR TITLE
ci: remove unneded build workflow permission

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,7 +8,6 @@ jobs:
     name: Build
     uses: ./.github/workflows/reusable-build.yml
     permissions:
-      contents: write
       statuses: write
     with:
       artifact-name: build


### PR DESCRIPTION
Comes from https://github.com/davidlj95/website

https://github.com/davidlj95/website/blob/550ccba06423c2e90743ac13ad45b31d61adedfc/.github/workflows/reusable-build.yml#L19-L23