### PR TITLE
perf(image-swiper): improve layout when JS not enabled

### DIFF
--- a/src/app/image-swiper/image-swiper.component.scss
+++ b/src/app/image-swiper/image-swiper.component.scss
@@ -5,8 +5,10 @@
     width: 100%;
     height: 100%;
     overflow: hidden;
+    display: flex;
 
     swiper-slide {
+      position: relative;
       max-height: inherit;
 
       img {


### PR DESCRIPTION
Until the swiper was initialized, the image swiper placed their images at full screen (because of the absolute positioning). Here we make those images be where they'll be in few seconds when the swiper loads. So less layout shift.
