### PR TITLE
build: add JSON files fetcher system

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -39,6 +39,7 @@
               "src/apple-touch-icon-precomposed.png",
               "src/assets",
               "src/browserconfig.xml",
+              "src/data",
               "src/favicon.ico",
               "src/favicon.svg",
               "src/robots.txt",
@@ -107,6 +108,7 @@
               "src/apple-touch-icon-precomposed.png",
               "src/assets",
               "src/browserconfig.xml",
+              "src/data",
               "src/favicon.ico",
               "src/favicon.svg",
               "src/robots.txt",
@@ -128,7 +130,8 @@
             "inlineStyleLanguage": "scss",
             "stylePreprocessorOptions": {
               "includePaths": ["src/sass"]
-            }
+            },
+            "assets": ["src/data"]
           },
           "configurations": {
             "production": {

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -15,6 +15,9 @@ module.exports = {
     assert: {
       preset: 'lighthouse:no-pwa',
       assertions: {
+        //👇 Didn't appear til main bundle was >500kb. Then, Lighthouse wants source maps
+        // If we optimize, we can probably turn this back on. 500kb for main bundle is a bit too much
+        'valid-source-maps': 'off',
         // 👇 Probably Swiper.js 😭
         // Just happens on project detail page tho, when many swipers in there
         // Maybe a grid would solve it

--- a/scripts/src/generate-image-lists.mts
+++ b/scripts/src/generate-image-lists.mts
@@ -14,22 +14,24 @@ import path from 'path'
 import { isMain } from './is-main.mjs'
 import { getRepositoryRootDir } from './get-repository-root-dir.mjs'
 import { Log } from './log.mjs'
+import directoriesPkg from '../../src/app/common/data/directories.js'
 
 const { IMAGEKIT_URL } = imagesConfigPkg
+const { DATA_DIR, PROJECTS_DIR } = directoriesPkg
 
 class ImageListsGenerator {
   private imageKit: ImageKit
   private readonly IMAGES_DATA_DIR = path.join(
     getRepositoryRootDir(),
     'src',
-    'data',
+    DATA_DIR,
     'images',
   )
   private readonly PROJECTS_DATA_DIR = path.join(
     getRepositoryRootDir(),
     'src',
-    'data',
-    'projects',
+    DATA_DIR,
+    PROJECTS_DIR,
   )
 
   constructor() {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -6,7 +6,11 @@ import { AppComponent } from './app.component'
 import { ProjectsPageComponent } from './projects-page/projects-page.component'
 import { HeaderComponent } from './header/header.component'
 import { ProjectItemComponent } from './projects-page/project-item/project-item.component'
-import { NgOptimizedImage, provideImageKitLoader } from '@angular/common'
+import {
+  APP_BASE_HREF,
+  NgOptimizedImage,
+  provideImageKitLoader,
+} from '@angular/common'
 import { LogoComponent } from './logo/logo.component'
 import { register as registerSwiper } from 'swiper/element/bundle'
 import { SwiperDirective } from './image-swiper/swiper.directive'
@@ -21,6 +25,9 @@ import { LookbookComponent } from './project-page/lookbooks/lookbook/lookbook.co
 import { TechMaterialComponent } from './project-page/tech-material/tech-material.component'
 import { ImageSwiperComponent } from './image-swiper/image-swiper.component'
 import { DesignBookComponent } from './project-page/design-book/design-book.component'
+import { JsonFetcher } from './common/json-fetcher/json-fetcher-injection-token'
+import { HttpJsonFetcherService } from './common/json-fetcher/http-json-fetcher.service'
+import { HttpClientModule } from '@angular/common/http'
 
 // There's no fancier way to install Web Components in Angular :P
 // https://stackoverflow.com/a/75353889/3263250
@@ -47,6 +54,7 @@ registerSwiper()
     AppRoutingModule,
     NgOptimizedImage,
     BrowserAnimationsModule,
+    HttpClientModule,
     SeoModule.forRoot({
       type: 'website',
       twitter: {
@@ -62,7 +70,11 @@ registerSwiper()
       ],
     }),
   ],
-  providers: [provideImageKitLoader(IMAGEKIT_URL)],
+  providers: [
+    provideImageKitLoader(IMAGEKIT_URL),
+    { provide: JsonFetcher, useClass: HttpJsonFetcherService },
+    { provide: APP_BASE_HREF, useValue: '/' },
+  ],
   bootstrap: [AppComponent],
   // Use swiper web components
   // A better approach would be to declare those but there's no easy way

--- a/src/app/app.server.module.ts
+++ b/src/app/app.server.module.ts
@@ -3,9 +3,12 @@ import { ServerModule } from '@angular/platform-server'
 
 import { AppModule } from './app.module'
 import { AppComponent } from './app.component'
+import { LocalJsonFetcherService } from './common/json-fetcher/local-json-fetcher.service'
+import { JsonFetcher } from './common/json-fetcher/json-fetcher-injection-token'
 
 @NgModule({
   imports: [AppModule, ServerModule],
   bootstrap: [AppComponent],
+  providers: [{ provide: JsonFetcher, useClass: LocalJsonFetcherService }],
 })
 export class AppServerModule {}

--- a/src/app/common/data/directories.ts
+++ b/src/app/common/data/directories.ts
@@ -1,0 +1,2 @@
+export const DATA_DIR = 'data'
+export const PROJECTS_DIR = 'projects'

--- a/src/app/common/data/files.ts
+++ b/src/app/common/data/files.ts
@@ -1,0 +1,3 @@
+export function getListFilename(directory: string) {
+  return `${directory}-list.json`
+}

--- a/src/app/common/json-fetcher/http-json-fetcher.service.spec.ts
+++ b/src/app/common/json-fetcher/http-json-fetcher.service.spec.ts
@@ -11,7 +11,7 @@ describe('HttpJsonFetcherService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
-      providers: [MockProvider(APP_BASE_HREF, '/')],
+      providers: [MockProvider(APP_BASE_HREF, '/'), HttpJsonFetcherService],
     })
     service = TestBed.inject(HttpJsonFetcherService)
   })

--- a/src/app/common/json-fetcher/http-json-fetcher.service.spec.ts
+++ b/src/app/common/json-fetcher/http-json-fetcher.service.spec.ts
@@ -11,7 +11,7 @@ describe('HttpJsonFetcherService', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
-      providers: [MockProvider(APP_BASE_HREF, '/'), HttpJsonFetcherService],
+      providers: [MockProvider(APP_BASE_HREF, '/')],
     })
     service = TestBed.inject(HttpJsonFetcherService)
   })

--- a/src/app/common/json-fetcher/http-json-fetcher.service.spec.ts
+++ b/src/app/common/json-fetcher/http-json-fetcher.service.spec.ts
@@ -1,0 +1,22 @@
+import { TestBed } from '@angular/core/testing'
+
+import { HttpJsonFetcherService } from './http-json-fetcher.service'
+import { HttpClientTestingModule } from '@angular/common/http/testing'
+import { MockProvider } from 'ng-mocks'
+import { APP_BASE_HREF } from '@angular/common'
+
+describe('HttpJsonFetcherService', () => {
+  let service: HttpJsonFetcherService
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [MockProvider(APP_BASE_HREF, '/')],
+    })
+    service = TestBed.inject(HttpJsonFetcherService)
+  })
+
+  it('should be created', () => {
+    expect(service).toBeTruthy()
+  })
+})

--- a/src/app/common/json-fetcher/http-json-fetcher.service.ts
+++ b/src/app/common/json-fetcher/http-json-fetcher.service.ts
@@ -5,7 +5,7 @@ import { Inject, Injectable } from '@angular/core'
 import { APP_BASE_HREF } from '@angular/common'
 import { Json } from './json-types'
 
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export class HttpJsonFetcherService implements JsonFetcher {
   constructor(
     private httpClient: HttpClient,

--- a/src/app/common/json-fetcher/http-json-fetcher.service.ts
+++ b/src/app/common/json-fetcher/http-json-fetcher.service.ts
@@ -5,9 +5,7 @@ import { Inject, Injectable } from '@angular/core'
 import { APP_BASE_HREF } from '@angular/common'
 import { Json } from './json-types'
 
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable()
 export class HttpJsonFetcherService implements JsonFetcher {
   constructor(
     private httpClient: HttpClient,

--- a/src/app/common/json-fetcher/http-json-fetcher.service.ts
+++ b/src/app/common/json-fetcher/http-json-fetcher.service.ts
@@ -1,0 +1,31 @@
+import { JSON_DATA_DIR, JsonFetcher } from './json-fetcher-injection-token'
+import { HttpClient } from '@angular/common/http'
+import { firstValueFrom } from 'rxjs'
+import { Inject, Injectable } from '@angular/core'
+import { APP_BASE_HREF } from '@angular/common'
+import { Json } from './json-types'
+
+@Injectable({
+  providedIn: 'root',
+})
+export class HttpJsonFetcherService implements JsonFetcher {
+  constructor(
+    private httpClient: HttpClient,
+    @Inject(APP_BASE_HREF) private baseHref: string,
+    @Inject(JSON_DATA_DIR) private jsonDataDir: string,
+  ) {}
+
+  async fetch(...pathSegments: string[]): Promise<Json | undefined> {
+    const response = firstValueFrom(
+      this.httpClient.get(
+        [this.baseHref, this.jsonDataDir, ...pathSegments]
+          .join('/')
+          .replace(/^\//, ''),
+      ),
+    )
+    if (!response) {
+      return
+    }
+    return response as unknown as Json
+  }
+}

--- a/src/app/common/json-fetcher/json-fetcher-injection-token.ts
+++ b/src/app/common/json-fetcher/json-fetcher-injection-token.ts
@@ -1,0 +1,11 @@
+import { InjectionToken } from '@angular/core'
+import { Json } from './json-types'
+import { DATA_DIR } from '../data/directories'
+
+export const JSON_DATA_DIR = new InjectionToken<string>('JSON data dir', {
+  factory: () => DATA_DIR,
+})
+
+export abstract class JsonFetcher {
+  abstract fetch(...pathSegments: string[]): Promise<Json | undefined>
+}

--- a/src/app/common/json-fetcher/json-types.d.ts
+++ b/src/app/common/json-fetcher/json-types.d.ts
@@ -1,0 +1,7 @@
+export interface Json {
+  [x: string]: string | number | boolean | Date | Json | JsonArray
+}
+
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface JsonArray
+  extends Array<string | number | boolean | Date | Json | JsonArray> {}

--- a/src/app/common/json-fetcher/local-json-fetcher.service.ts
+++ b/src/app/common/json-fetcher/local-json-fetcher.service.ts
@@ -4,7 +4,7 @@ import * as path from 'path'
 import * as fs from 'fs'
 import { Json } from './json-types'
 
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export class LocalJsonFetcherService implements JsonFetcher {
   constructor(@Inject(JSON_DATA_DIR) private jsonDataDir: string) {}
 

--- a/src/app/common/json-fetcher/local-json-fetcher.service.ts
+++ b/src/app/common/json-fetcher/local-json-fetcher.service.ts
@@ -4,9 +4,7 @@ import * as path from 'path'
 import * as fs from 'fs'
 import { Json } from './json-types'
 
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable()
 export class LocalJsonFetcherService implements JsonFetcher {
   constructor(@Inject(JSON_DATA_DIR) private jsonDataDir: string) {}
 

--- a/src/app/common/json-fetcher/local-json-fetcher.service.ts
+++ b/src/app/common/json-fetcher/local-json-fetcher.service.ts
@@ -1,0 +1,19 @@
+import { Inject, Injectable } from '@angular/core'
+import { JSON_DATA_DIR, JsonFetcher } from './json-fetcher-injection-token'
+import * as path from 'path'
+import * as fs from 'fs'
+import { Json } from './json-types'
+
+@Injectable({
+  providedIn: 'root',
+})
+export class LocalJsonFetcherService implements JsonFetcher {
+  constructor(@Inject(JSON_DATA_DIR) private jsonDataDir: string) {}
+
+  async fetch(...pathSegments: string[]): Promise<Json | undefined> {
+    const jsonFile = path.resolve(__dirname, this.jsonDataDir, ...pathSegments)
+    //👇 Promises would be out of zone.js, so using sync. Could be improved
+    const contents = fs.readFileSync(jsonFile)
+    return JSON.parse(contents.toString())
+  }
+}


### PR DESCRIPTION
Now all data JSON files are imported into the app's code. This means the data is embedded in the app package. Now there's only 1 project and some images here and there, so not an issue. But this can be an issue when more data get added.

So in order to request the JSON file instead of embedding it, adding here the `JsonFetcher` service.

In the server, it reads the JSON file using `fs` Node.js APIs.
 - Data files are now added as resources to server build.
In the browser, it fetches the JSON file using HTTP reqs.
 - Data files are exposed when building the application as static assets

Tested it works properly first by replacing preview images service. But that was optimised and removed in #69 So tested it again with projects service. PR to use this with projects service will follow this one.

## Changes
- Add json fetcher injection token
- Add http json fetcher for browser. Set it as provider of json fetcher in the app module.
- Import HTTP client module
- Expose `data` directory as static assets
- Add local json fetcher for server. Override it as provider of json fetcher in server app module.
- Add `data` directory as server assets
- Add directories / files consts and functions so that app and generator scripts read and write same files
- Fix tests around
- Use abstract class to avoid creating an injection token object
- Adding the HTTP module made [Lighthouse fail](https://github.com/davidlj95/chrislb/actions/runs/6681755350/job/18156210233?pr=70)
  Turns out we exceed 500kb of main bundle size due to this HTTP module being included (analyzed the bundle with source explorer). Then, Lighthouse wants to see source maps for this big file. If the file is not so big, source maps are not required by Lighthouse. Adding exception for now. Source maps are not emitted in production by default in Angular. But seems until main bundle is not big, Lighthouse is happy with that.
- Played a bit to see if the `@Injectable` decorator made a difference in the bundle size. No diff. No diff for when using `providedIn: 'root'` either. So leaving it like that (injectable + in root).
  - Was worried that injecting the local json fetcher, would include browserifications of fs/path APIs