### PR TITLE
perf(projects): fetch specific project json

### DIFF
--- a/src/app/common/data/files.ts
+++ b/src/app/common/data/files.ts
@@ -1,3 +1,7 @@
 export function getListFilename(directory: string) {
   return `${directory}-list.json`
 }
+
+export function addJsonExtension(filename: string): string {
+  return `${filename}.json`
+}

--- a/src/app/project-page/project-page.component.spec.ts
+++ b/src/app/project-page/project-page.component.spec.ts
@@ -6,7 +6,7 @@ import { LookbooksComponent } from './lookbooks/lookbooks.component'
 import { TechMaterialComponent } from './tech-material/tech-material.component'
 import { DesignBookComponent } from './design-book/design-book.component'
 import { ProjectsService } from '../projects-page/projects.service'
-import { ProjectItem } from '../projects-page/project-item/project-item'
+import { Project } from '../projects-page/project-item/project-item'
 
 describe('ProjectPageComponent', () => {
   let component: ProjectPageComponent
@@ -24,8 +24,8 @@ describe('ProjectPageComponent', () => {
       ],
       providers: [
         MockProvider(ProjectsService, {
-          async bySlug(): Promise<ProjectItem> {
-            return { title: 'Title', description: 'Description' } as ProjectItem
+          async bySlug(): Promise<Project> {
+            return { title: 'Title', description: 'Description' } as Project
           },
         }),
       ],

--- a/src/app/projects-page/project-item/project-item.component.ts
+++ b/src/app/projects-page/project-item/project-item.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core'
-import { Credit, ProjectItem } from './project-item'
+import { Credit, ProjectListItem } from './project-item'
 import { SwiperOptions } from 'swiper/types'
 import { PROJECTS_PATH } from '../../routes'
 import { ImageResponsiveBreakpointsService } from '../../common/image-responsive-breakpoints.service'
@@ -11,9 +11,9 @@ import { Author, AuthorsService } from '../../common/authors.service'
   styleUrls: ['./project-item.component.scss'],
 })
 export class ProjectItemComponent {
-  protected _item!: ProjectItem
+  protected _item!: ProjectListItem
   @Input({ required: true })
-  public set item(item: ProjectItem) {
+  public set item(item: ProjectListItem) {
     this._item = item
     this.credits = item.credits.map((credit) => ({
       ...credit,

--- a/src/app/projects-page/project-item/project-item.ts
+++ b/src/app/projects-page/project-item/project-item.ts
@@ -1,12 +1,15 @@
 import { ImageAsset } from '../../../data/images/types'
 
-export interface ProjectItem {
+export interface Project {
   readonly slug: string
   readonly title: string
   readonly subtitle: string
   readonly quote?: string
   readonly description: string
   readonly credits: readonly Credit[]
+}
+
+export interface ProjectListItem extends Project {
   readonly previewImages: ReadonlyArray<ImageAsset>
 }
 

--- a/src/app/projects-page/projects-page.component.ts
+++ b/src/app/projects-page/projects-page.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core'
-import { ProjectItem } from './project-item/project-item'
 import { ProjectsService } from './projects.service'
+import { ProjectListItem } from './project-item/project-item'
 
 @Component({
   selector: 'app-projects-page',
@@ -8,7 +8,7 @@ import { ProjectsService } from './projects.service'
   styleUrls: ['./projects-page.component.scss'],
 })
 export class ProjectsPageComponent {
-  public readonly projects: Promise<ReadonlyArray<ProjectItem>>
+  public readonly projects: Promise<ReadonlyArray<ProjectListItem>>
 
   constructor(projectsService: ProjectsService) {
     this.projects = projectsService.getAll()

--- a/src/app/projects-page/projects.service.ts
+++ b/src/app/projects-page/projects.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core'
-import { ProjectItem } from './project-item/project-item'
 import { JsonFetcher } from '../common/json-fetcher/json-fetcher-injection-token'
 import { PROJECTS_DIR } from '../common/data/directories'
-import { getListFilename } from '../common/data/files'
+import { addJsonExtension, getListFilename } from '../common/data/files'
+import { Project, ProjectListItem } from './project-item/project-item'
 
 @Injectable({
   providedIn: 'root',
@@ -10,14 +10,18 @@ import { getListFilename } from '../common/data/files'
 export class ProjectsService {
   constructor(private jsonFetcher: JsonFetcher) {}
 
-  async getAll(): Promise<ReadonlyArray<ProjectItem>> {
-    return (await this.jsonFetcher.fetch(
+  async getAll(): Promise<ReadonlyArray<ProjectListItem>> {
+    const listItems = await this.jsonFetcher.fetch(
       getListFilename(PROJECTS_DIR),
-    )) as unknown as ReadonlyArray<ProjectItem>
+    )
+    return (listItems as ReadonlyArray<ProjectListItem> | undefined) ?? []
   }
 
-  async bySlug(slug: string): Promise<ProjectItem | null> {
-    const allProjects = await this.getAll()
-    return allProjects.find((project) => project.slug === slug) ?? null
+  async bySlug(slug: string): Promise<Project | undefined> {
+    const project = await this.jsonFetcher.fetch(
+      PROJECTS_DIR,
+      addJsonExtension(slug),
+    )
+    return project as Project | undefined
   }
 }


### PR DESCRIPTION
Change implementation of project by slug method to fetch specific JSON only.

Also renames `ProjectItem` to `Project`. And creates `ProjectListItem`, which is `Project` + `previewImages` needed when listing projects.
