### PR TITLE
refactor: fetcher to use generic type

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -25,7 +25,7 @@ import { LookbookComponent } from './project-page/lookbooks/lookbook/lookbook.co
 import { TechMaterialComponent } from './project-page/tech-material/tech-material.component'
 import { ImageSwiperComponent } from './image-swiper/image-swiper.component'
 import { DesignBookComponent } from './project-page/design-book/design-book.component'
-import { JsonFetcher } from './common/json-fetcher/json-fetcher-injection-token'
+import { JsonFetcher } from './common/json-fetcher/json-fetcher'
 import { HttpJsonFetcherService } from './common/json-fetcher/http-json-fetcher.service'
 import { HttpClientModule } from '@angular/common/http'
 

--- a/src/app/app.server.module.ts
+++ b/src/app/app.server.module.ts
@@ -4,7 +4,7 @@ import { ServerModule } from '@angular/platform-server'
 import { AppModule } from './app.module'
 import { AppComponent } from './app.component'
 import { LocalJsonFetcherService } from './common/json-fetcher/local-json-fetcher.service'
-import { JsonFetcher } from './common/json-fetcher/json-fetcher-injection-token'
+import { JsonFetcher } from './common/json-fetcher/json-fetcher'
 
 @NgModule({
   imports: [AppModule, ServerModule],

--- a/src/app/common/json-fetcher/http-json-fetcher.service.ts
+++ b/src/app/common/json-fetcher/http-json-fetcher.service.ts
@@ -1,9 +1,8 @@
-import { JSON_DATA_DIR, JsonFetcher } from './json-fetcher-injection-token'
+import { JSON_DATA_DIR, JsonFetcher } from './json-fetcher'
 import { HttpClient } from '@angular/common/http'
 import { firstValueFrom } from 'rxjs'
 import { Inject, Injectable } from '@angular/core'
 import { APP_BASE_HREF } from '@angular/common'
-import { Json } from './json-types'
 
 @Injectable({ providedIn: 'root' })
 export class HttpJsonFetcherService implements JsonFetcher {
@@ -13,17 +12,13 @@ export class HttpJsonFetcherService implements JsonFetcher {
     @Inject(JSON_DATA_DIR) private jsonDataDir: string,
   ) {}
 
-  async fetch(...pathSegments: string[]): Promise<Json | undefined> {
-    const response = firstValueFrom(
-      this.httpClient.get(
+  async fetch<T>(...pathSegments: string[]): Promise<T> {
+    return firstValueFrom(
+      this.httpClient.get<T>(
         [this.baseHref, this.jsonDataDir, ...pathSegments]
           .join('/')
           .replace(/^\//, ''),
       ),
     )
-    if (!response) {
-      return
-    }
-    return response as unknown as Json
   }
 }

--- a/src/app/common/json-fetcher/json-fetcher.ts
+++ b/src/app/common/json-fetcher/json-fetcher.ts
@@ -1,5 +1,4 @@
 import { InjectionToken } from '@angular/core'
-import { Json } from './json-types'
 import { CONTENTS_DIR } from '../directories'
 
 export const JSON_DATA_DIR = new InjectionToken<string>('JSON data dir', {
@@ -7,5 +6,5 @@ export const JSON_DATA_DIR = new InjectionToken<string>('JSON data dir', {
 })
 
 export abstract class JsonFetcher {
-  abstract fetch(...pathSegments: string[]): Promise<Json | undefined>
+  abstract fetch<T>(...pathSegments: string[]): Promise<T>
 }

--- a/src/app/common/json-fetcher/json-types.d.ts
+++ b/src/app/common/json-fetcher/json-types.d.ts
@@ -1,7 +1,0 @@
-export interface Json {
-  [x: string]: string | number | boolean | Date | Json | JsonArray
-}
-
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-interface JsonArray
-  extends Array<string | number | boolean | Date | Json | JsonArray> {}

--- a/src/app/common/json-fetcher/local-json-fetcher.service.ts
+++ b/src/app/common/json-fetcher/local-json-fetcher.service.ts
@@ -1,14 +1,13 @@
 import { Inject, Injectable } from '@angular/core'
-import { JSON_DATA_DIR, JsonFetcher } from './json-fetcher-injection-token'
+import { JSON_DATA_DIR, JsonFetcher } from './json-fetcher'
 import * as path from 'path'
 import * as fs from 'fs'
-import { Json } from './json-types'
 
 @Injectable({ providedIn: 'root' })
 export class LocalJsonFetcherService implements JsonFetcher {
   constructor(@Inject(JSON_DATA_DIR) private jsonDataDir: string) {}
 
-  async fetch(...pathSegments: string[]): Promise<Json | undefined> {
+  async fetch<T>(...pathSegments: string[]): Promise<T> {
     const jsonFile = path.resolve(__dirname, this.jsonDataDir, ...pathSegments)
     //👇 Promises would be out of zone.js, so using sync. Could be improved
     const contents = fs.readFileSync(jsonFile)

--- a/src/app/project-page/design-book/design-book.component.spec.ts
+++ b/src/app/project-page/design-book/design-book.component.spec.ts
@@ -4,7 +4,6 @@ import { DesignBookComponent } from './design-book.component'
 import { MockComponents, MockProvider } from 'ng-mocks'
 import { ImageSwiperComponent } from '../../image-swiper/image-swiper.component'
 import { ProjectImagesService } from '../project-images.service'
-import { of } from 'rxjs'
 
 describe('DesignBookComponent', () => {
   let component: DesignBookComponent
@@ -15,8 +14,8 @@ describe('DesignBookComponent', () => {
       declarations: [DesignBookComponent, MockComponents(ImageSwiperComponent)],
       providers: [
         MockProvider(ProjectImagesService, {
-          bySlugAndFilename() {
-            return of()
+          async bySlugAndFilename() {
+            return []
           },
         }),
       ],

--- a/src/app/project-page/design-book/design-book.component.ts
+++ b/src/app/project-page/design-book/design-book.component.ts
@@ -1,5 +1,4 @@
 import { Component, Input } from '@angular/core'
-import { Observable } from 'rxjs'
 import { ImageAsset } from '../../../data/images/types'
 import { SwiperOptions } from 'swiper/types'
 import { ImageResponsiveBreakpointsService } from '../../common/image-responsive-breakpoints.service'
@@ -19,7 +18,7 @@ export class DesignBookComponent {
     )
   }
 
-  public images!: Observable<ReadonlyArray<ImageAsset>>
+  public images!: Promise<ReadonlyArray<ImageAsset>>
   public readonly srcSet = this.imageResponsiveBreakpointsService
     .range(
       this.imageResponsiveBreakpointsService.MIN_SCREEN_WIDTH_PX,

--- a/src/app/project-page/lookbooks/lookbooks.component.spec.ts
+++ b/src/app/project-page/lookbooks/lookbooks.component.spec.ts
@@ -4,7 +4,6 @@ import { LookbooksComponent } from './lookbooks.component'
 import { MockComponents, MockProvider } from 'ng-mocks'
 import { LookbookComponent } from './lookbook/lookbook.component'
 import { ProjectLookbooksService } from './project-lookbooks.service'
-import { of } from 'rxjs'
 
 describe('LookbooksComponent', () => {
   let component: LookbooksComponent
@@ -15,8 +14,8 @@ describe('LookbooksComponent', () => {
       declarations: [LookbooksComponent, MockComponents(LookbookComponent)],
       providers: [
         MockProvider(ProjectLookbooksService, {
-          bySlug() {
-            return of([])
+          async bySlug() {
+            return []
           },
         }),
       ],

--- a/src/app/project-page/lookbooks/lookbooks.component.ts
+++ b/src/app/project-page/lookbooks/lookbooks.component.ts
@@ -1,5 +1,4 @@
 import { Component, Input } from '@angular/core'
-import { Observable } from 'rxjs'
 import { ProjectLookbooksService } from './project-lookbooks.service'
 import { Lookbook } from './lookbook/lookbook'
 
@@ -9,7 +8,7 @@ import { Lookbook } from './lookbook/lookbook'
   styleUrls: ['./lookbooks.component.scss'],
 })
 export class LookbooksComponent {
-  public lookbooks?: Observable<ReadonlyArray<Lookbook>>
+  public lookbooks!: Promise<ReadonlyArray<Lookbook>>
   protected readonly MAX_LOOKBOOKS_PER_VIEWPORT = 2
 
   constructor(private lookbooksService: ProjectLookbooksService) {}

--- a/src/app/project-page/lookbooks/project-lookbooks.service.spec.ts
+++ b/src/app/project-page/lookbooks/project-lookbooks.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing'
 
 import { ProjectLookbooksService } from './project-lookbooks.service'
 import { MockProviders } from 'ng-mocks'
-import { JsonFetcher } from '../../common/json-fetcher/json-fetcher-injection-token'
+import { JsonFetcher } from '../../common/json-fetcher/json-fetcher'
 
 describe('ProjectLookbooksService', () => {
   let service: ProjectLookbooksService

--- a/src/app/project-page/lookbooks/project-lookbooks.service.ts
+++ b/src/app/project-page/lookbooks/project-lookbooks.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core'
-import { from, Observable } from 'rxjs'
 import { Lookbook } from './lookbook/lookbook'
-import { JsonFetcher } from '../../common/json-fetcher/json-fetcher-injection-token'
+import { JsonFetcher } from '../../common/json-fetcher/json-fetcher'
 import { PROJECTS_DIR } from '../../common/directories'
 import { LOOKBOOKS_IMAGES_FILENAME } from '../../common/files'
 
@@ -11,18 +10,11 @@ import { LOOKBOOKS_IMAGES_FILENAME } from '../../common/files'
 export class ProjectLookbooksService {
   constructor(private jsonFetcher: JsonFetcher) {}
 
-  bySlug(projectSlug: string): Observable<ReadonlyArray<Lookbook>> {
-    return from(this.getLookbooks(projectSlug))
-  }
-
-  private async getLookbooks(
-    projectSlug: string,
-  ): Promise<ReadonlyArray<Lookbook>> {
-    const lookbooksImages = await this.jsonFetcher.fetch(
+  bySlug(projectSlug: string): Promise<ReadonlyArray<Lookbook>> {
+    return this.jsonFetcher.fetch<ReadonlyArray<Lookbook>>(
       PROJECTS_DIR,
       projectSlug,
       LOOKBOOKS_IMAGES_FILENAME,
     )
-    return (lookbooksImages as ReadonlyArray<Lookbook> | undefined) ?? []
   }
 }

--- a/src/app/project-page/project-images.service.spec.ts
+++ b/src/app/project-page/project-images.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing'
 
 import { ProjectImagesService } from './project-images.service'
 import { MockProviders } from 'ng-mocks'
-import { JsonFetcher } from '../common/json-fetcher/json-fetcher-injection-token'
+import { JsonFetcher } from '../common/json-fetcher/json-fetcher'
 
 describe('ProjectImagesService', () => {
   let service: ProjectImagesService

--- a/src/app/project-page/project-images.service.ts
+++ b/src/app/project-page/project-images.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core'
-import { from, Observable } from 'rxjs'
 import { ImageAsset } from '../../data/images/types'
-import { JsonFetcher } from '../common/json-fetcher/json-fetcher-injection-token'
+import { JsonFetcher } from '../common/json-fetcher/json-fetcher'
 import { PROJECTS_DIR } from '../common/directories'
 
 @Injectable({
@@ -13,11 +12,7 @@ export class ProjectImagesService {
   bySlugAndFilename(
     slug: string,
     filename: string,
-  ): Observable<ReadonlyArray<ImageAsset>> {
-    const imagesPromise = async () => {
-      const images = await this.jsonFetcher.fetch(PROJECTS_DIR, slug, filename)
-      return (images as ReadonlyArray<ImageAsset> | undefined) ?? []
-    }
-    return from(imagesPromise())
+  ): Promise<ReadonlyArray<ImageAsset>> {
+    return this.jsonFetcher.fetch(PROJECTS_DIR, slug, filename)
   }
 }

--- a/src/app/project-page/tech-material/tech-material.component.spec.ts
+++ b/src/app/project-page/tech-material/tech-material.component.spec.ts
@@ -4,7 +4,6 @@ import { TechMaterialComponent } from './tech-material.component'
 import { MockComponents, MockProvider } from 'ng-mocks'
 import { ImageSwiperComponent } from '../../image-swiper/image-swiper.component'
 import { ProjectImagesService } from '../project-images.service'
-import { of } from 'rxjs'
 
 describe('TechMaterialComponent', () => {
   let component: TechMaterialComponent
@@ -18,8 +17,8 @@ describe('TechMaterialComponent', () => {
       ],
       providers: [
         MockProvider(ProjectImagesService, {
-          bySlugAndFilename() {
-            return of([])
+          async bySlugAndFilename() {
+            return []
           },
         }),
       ],

--- a/src/app/project-page/tech-material/tech-material.component.ts
+++ b/src/app/project-page/tech-material/tech-material.component.ts
@@ -1,6 +1,5 @@
 import { Component, Input } from '@angular/core'
 import { SwiperOptions } from 'swiper/types'
-import { Observable } from 'rxjs'
 import { ImageAsset } from '../../../data/images/types'
 import { ProjectImagesService } from '../project-images.service'
 import { ImageResponsiveBreakpointsService } from '../../common/image-responsive-breakpoints.service'
@@ -19,7 +18,7 @@ export class TechMaterialComponent {
     )
   }
 
-  public techMaterials!: Observable<ReadonlyArray<ImageAsset>>
+  public techMaterials!: Promise<ReadonlyArray<ImageAsset>>
   public readonly srcSet = this.imageResponsiveBreakpointsService
     .range(
       this.imageResponsiveBreakpointsService.MIN_SCREEN_WIDTH_PX,

--- a/src/app/projects-page/projects.service.spec.ts
+++ b/src/app/projects-page/projects.service.spec.ts
@@ -1,7 +1,7 @@
 import { TestBed } from '@angular/core/testing'
 
 import { ProjectsService } from './projects.service'
-import { JsonFetcher } from '../common/json-fetcher/json-fetcher-injection-token'
+import { JsonFetcher } from '../common/json-fetcher/json-fetcher'
 import { MockProviders } from 'ng-mocks'
 
 describe('ProjectsService', () => {

--- a/src/app/projects-page/projects.service.ts
+++ b/src/app/projects-page/projects.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core'
-import { JsonFetcher } from '../common/json-fetcher/json-fetcher-injection-token'
+import { JsonFetcher } from '../common/json-fetcher/json-fetcher'
 import { PROJECTS_DIR } from '../common/directories'
 import { addJsonExtension, getListFilename } from '../common/files'
 import { Project, ProjectListItem } from './project-item/project-item'
@@ -11,17 +11,10 @@ export class ProjectsService {
   constructor(private jsonFetcher: JsonFetcher) {}
 
   async getAll(): Promise<ReadonlyArray<ProjectListItem>> {
-    const listItems = await this.jsonFetcher.fetch(
-      getListFilename(PROJECTS_DIR),
-    )
-    return (listItems as ReadonlyArray<ProjectListItem> | undefined) ?? []
+    return this.jsonFetcher.fetch(getListFilename(PROJECTS_DIR))
   }
 
-  async bySlug(slug: string): Promise<Project | undefined> {
-    const project = await this.jsonFetcher.fetch(
-      PROJECTS_DIR,
-      addJsonExtension(slug),
-    )
-    return project as Project | undefined
+  async bySlug(slug: string): Promise<Project> {
+    return this.jsonFetcher.fetch(PROJECTS_DIR, addJsonExtension(slug))
   }
 }


### PR DESCRIPTION
So that consumers don't have to cast every time. Similar to how Angular's `HttpClient` methods (like `get`) work. Also, remove the `undefined` case. If can't be fetched, will raise an error. And consumer must handle the error as they prefer (similar to `HttpClient` indeed, where the observable emits an error).

Consistently use `Promise` instead of `Observable` around (we're not gonna emit more than 1 value and don't need the RxJs powers (yet?))

Rename file containing json fetcher to avoid use of `injection-token` suffix (no longer an injection token)
