### PR TITLE
fix: missing extension in scripts

### DIFF
--- a/scripts/src/generate-content.mts
+++ b/scripts/src/generate-content.mts
@@ -7,7 +7,7 @@ import { Dirent } from 'fs'
 import directoriesPkg from '../../src/app/common/directories.js'
 import filesPkg from '../../src/app/common/files.js'
 import lookbookNamesAndSlugs from '../../src/data/lookbooks/names-by-slug.json' assert { type: 'json' }
-import { Lookbook } from '../../src/app/project-page/lookbook'
+import { Lookbook } from '../../src/app/project-page/lookbook.js'
 import { JsonFile } from './json-file.mjs'
 
 const { CONTENTS_DIR, PROJECTS_DIR, DATA_DIR } = directoriesPkg

--- a/scripts/src/generate-image-lists.mts
+++ b/scripts/src/generate-image-lists.mts
@@ -9,7 +9,7 @@ import { isMain } from './is-main.mjs'
 import { getRepositoryRootDir } from './get-repository-root-dir.mjs'
 import { Log } from './log.mjs'
 import directoriesPkg from '../../src/app/common/directories.js'
-import { Lookbook } from '../../src/app/project-page/lookbook'
+import { Lookbook } from '../../src/app/project-page/lookbook.js'
 import filesPkg from '../../src/app/common/files.js'
 import { JsonFile } from './json-file.mjs'
 


### PR DESCRIPTION
Merged without waiting for CI cause Cloudflare error prevented CI from passing (Lighthouse + Cloudflare Pages). So merged everything assumed was fine.
