### PR TITLE
feat(projects): allow for projects without preview images

### DIFF
--- a/src/app/projects-page/project-item/project-item.component.html
+++ b/src/app/projects-page/project-item/project-item.component.html
@@ -15,6 +15,7 @@
     <div class="description" [innerHtml]="_item.description"></div>
   </div>
   <app-images-swiper
+    *ngIf="_item.previewImages && _item.previewImages.length"
     [images]="_item.previewImages"
     sizes="calc(50vw - 16px), 33.33vw"
     [srcSet]="srcSet"
@@ -22,7 +23,7 @@
     [customSwiperOptions]="CUSTOM_SWIPER_OPTIONS"
   ></app-images-swiper>
 </div>
-<div class="credits" *ngIf="credits.length">
+<div class="credits" *ngIf="credits && credits.length">
   <ng-container *ngFor="let credit of credits">
     <span *ngIf="credit.author">
       {{ credit.role }}: {{ credit.author.name }}

--- a/src/app/projects-page/project-item/project-item.component.scss
+++ b/src/app/projects-page/project-item/project-item.component.scss
@@ -28,7 +28,6 @@
   .texts {
     display: flex;
     flex-direction: column;
-    width: $texts-width-big-screen;
   }
 
   app-images-swiper {
@@ -45,7 +44,6 @@
     }
 
     .texts {
-      width: unset;
       order: 2;
     }
 

--- a/src/app/projects-page/project-item/project-item.component.ts
+++ b/src/app/projects-page/project-item/project-item.component.ts
@@ -15,7 +15,7 @@ export class ProjectItemComponent {
   @Input({ required: true })
   public set item(item: ProjectListItem) {
     this._item = item
-    this.credits = item.credits.map((credit) => ({
+    this.credits = item.credits?.map((credit) => ({
       ...credit,
       author: this.authorsService.bySlug(credit.authorSlug),
     }))
@@ -31,7 +31,7 @@ export class ProjectItemComponent {
       this.imageResponsiveBreakpointsService.MAX_SCREEN_WIDTH_PX / 3,
     )
     .toSrcSet()
-  public credits!: ReadonlyArray<CreditItem>
+  public credits?: ReadonlyArray<CreditItem>
   protected readonly PROJECTS_PATH = PROJECTS_PATH
 
   constructor(

--- a/src/app/projects-page/project-item/project-item.ts
+++ b/src/app/projects-page/project-item/project-item.ts
@@ -6,11 +6,13 @@ export interface Project {
   readonly subtitle: string
   readonly quote?: string
   readonly description: string
-  readonly credits: readonly Credit[]
+  //👇 When hasn't been set, CMS doesn't set the property
+  //   CMS sets it after though (if adding & removing)
+  readonly credits?: readonly Credit[]
 }
 
 export interface ProjectListItem extends Project {
-  readonly previewImages: ReadonlyArray<ImageAsset>
+  readonly previewImages?: ReadonlyArray<ImageAsset>
 }
 
 export interface Credit {

--- a/src/app/projects-page/projects-page.component.html
+++ b/src/app/projects-page/projects-page.component.html
@@ -2,4 +2,5 @@
   *ngFor="let item of projects | async; first as isFirst"
   [item]="item"
   [priority]="isFirst"
+  [class.has-preview-images]="item.previewImages && item.previewImages.length"
 ></app-project-item>

--- a/src/app/projects-page/projects-page.component.scss
+++ b/src/app/projects-page/projects-page.component.scss
@@ -1,8 +1,20 @@
 @use 'page';
+@use 'margins';
 
 :host {
   @include page.padding;
 
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: margins.$l;
+
+  app-project-item {
+    flex: 1;
+
+    &.has-preview-images {
+      flex: unset;
+      max-width: 100%;
+    }
+  }
 }


### PR DESCRIPTION
Create a new project from CMS and see what happens.

As credits are optional, they were undefined (instead of empty list). So adding code to support that case.

Also preview images weren't there. Adding code to support that case.

Finally, changed projects page layout to display in rows. So that project items without images can be placed in same row. Added class to distinguish project items that need full screen size (have images) from the ones that are text only.