### PR TITLE
fix: missing extension in script + wrong sizes lookbook

### DIFF
--- a/scripts/src/generate-content.mts
+++ b/scripts/src/generate-content.mts
@@ -7,7 +7,7 @@ import { Dirent } from 'fs'
 import directoriesPkg from '../../src/app/common/directories.js'
 import filesPkg from '../../src/app/common/files.js'
 import lookbookNamesAndSlugs from '../../src/data/lookbooks/names-by-slug.json' assert { type: 'json' }
-import { Lookbook } from '../../src/app/project-page/lookbook'
+import { Lookbook } from '../../src/app/project-page/lookbook.js'
 import { JsonFile } from './json-file.mjs'
 
 const { CONTENTS_DIR, PROJECTS_DIR, DATA_DIR } = directoriesPkg

--- a/scripts/src/generate-image-lists.mts
+++ b/scripts/src/generate-image-lists.mts
@@ -9,7 +9,7 @@ import { isMain } from './is-main.mjs'
 import { getRepositoryRootDir } from './get-repository-root-dir.mjs'
 import { Log } from './log.mjs'
 import directoriesPkg from '../../src/app/common/directories.js'
-import { Lookbook } from '../../src/app/project-page/lookbook'
+import { Lookbook } from '../../src/app/project-page/lookbook.js'
 import filesPkg from '../../src/app/common/files.js'
 import { JsonFile } from './json-file.mjs'
 

--- a/src/app/project-page/project-page.component.ts
+++ b/src/app/project-page/project-page.component.ts
@@ -79,7 +79,7 @@ export class ProjectPageComponent {
         )
         .pxValues.concat([this.LOOKBOOK_MAX_SLIDE_WIDTH_PX]),
     ).toSrcSet(),
-    sizes: `'alc(50vw - 16px), ${this.LOOKBOOK_MAX_SLIDE_WIDTH_PX}px`,
+    sizes: `calc(50vw - 16px), ${this.LOOKBOOK_MAX_SLIDE_WIDTH_PX}px`,
   }
 
   constructor(


### PR DESCRIPTION
Merged something without Lighthouse passing (as CI was temporarily unavailable due to Cloudflare KV outage -> `npm i` of Lighthouse failed). Aaaaaand was wrong. Fixing here.

Includes #82 (both needed for checks to pass)