### PR TITLE
feat(deploy): configure Cloudflare Pages to return 404

### DIFF
--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -5,6 +5,7 @@ prebuild:
 
 build: prebuild
 	npm run prerender
+	npm run postbuild
 
 install:
   # So @ngaox/seo installs (declares peer dep of Angular 15)

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "generate-content": "ts-node scripts/src/generate-content.mts",
     "cms-server": "npx decap-server",
     "prebuild": "npm run generate-image-lists && npm run generate-content",
-    "analyze-main-bundle": "ng build --source-map && npx source-map-explorer dist/chrislb/browser/main.*.js"
+    "analyze-main-bundle": "ng build --source-map && npx source-map-explorer dist/chrislb/browser/main.*.js",
+    "postbuild": "cp dist/chrislb/browser/404/index.html dist/chrislb/browser/content/404.html"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Cloudflare Pages returns the `index.html` when requesting a path that cannot be found. In order to [support single page applications (SPA)](https://developers.cloudflare.com/pages/platform/serving-pages/#single-page-application-spa-rendering). 

That's cool, but when fetching content JSON files from the `contents` directory, we want to receive a proper 404 if can't be found (so we can act properly)

The solution [to enable this 404 behaviour (instead of returning `index.html`) when something is not found is to add a `404.html` page](https://developers.cloudflare.com/pages/platform/serving-pages/#not-found-behavior)

Given we only need 404 statuses for the `contents` directory, the `404` prerendered page is copied in that directory as a `postbuild` step. 

Tested it manually by uploading new build within Cloudflare website and it works 🎉 