### PR TITLE
feat(projects): allow embedding videos via Youtube Playlist

### DIFF
--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -150,6 +150,11 @@ collections:
       - label: 'Description'
         name: 'description'
         widget: 'text'
+      - label: 'YouTube Playlist ID'
+        name: 'youtubePlaylistId'
+        widget: 'string'
+        required: false
+        hint: 'In case you want to attach some videos, create a YouTube Playlist with those videos. Then, click on share button in the playlist. Copy and paste the link, and extract whatever comes as list ID (after the "list" parameter). For instance, a sample link could be "https://youtube.com/playlist?list=PLbAKzQYf5_ME9HVqX2laYHNWCny96L5aI&si=zjfX69n2iqzZeVN4". In there, the playlist ID is "PLbAKzQYf5_ME9HVqX2laYHNWCny96L5aI"'
       - label: 'Credits'
         name: 'credits'
         widget: 'list'

--- a/src/app/project-page/project-page.component.html
+++ b/src/app/project-page/project-page.component.html
@@ -1,4 +1,16 @@
 <ng-container *ngIf="data$ | async as data">
+  <div class="videos" *ngIf="youtubeIframeUrl">
+    <h2>Videos</h2>
+    <iframe
+      width="560"
+      height="315"
+      [attr.src]="youtubeIframeUrl"
+      title="YouTube video player"
+      frameborder="0"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+      allowfullscreen
+    ></iframe>
+  </div>
   <div class="lookbooks" *ngIf="data.lookbooks?.length">
     <div
       class="lookbook"

--- a/src/app/project-page/project-page.component.scss
+++ b/src/app/project-page/project-page.component.scss
@@ -8,6 +8,18 @@
   @include page.padding;
   gap: margins.$m;
 
+  .videos {
+    display: flex;
+    flex-direction: column;
+    gap: margins.$m;
+    place-content: center;
+    align-items: center;
+
+    iframe {
+      max-width: 100%;
+    }
+  }
+
   h2 {
     text-align: center;
   }

--- a/src/app/project-page/project-page.component.ts
+++ b/src/app/project-page/project-page.component.ts
@@ -24,6 +24,7 @@ import {
 import { Lookbook } from './lookbook'
 import { ProjectLookbooksService } from './project-lookbooks.service'
 import { ImageResponsiveBreakpoints } from '../common/image-responsive-breakpoints'
+import { DomSanitizer, SafeUrl } from '@angular/platform-browser'
 
 @Component({
   selector: 'app-project-page',
@@ -34,6 +35,9 @@ export class ProjectPageComponent {
   @Input({ required: true })
   public set slug(slug: string) {
     this.projectsService.bySlug(slug).then((projectItem) => {
+      if (projectItem.youtubePlaylistId) {
+        this.youtubePlaylistId = projectItem.youtubePlaylistId
+      }
       this.seo.setUrl(getCanonicalUrlForPath(PROJECTS_PATH, slug))
       if (!projectItem) {
         displayNotFound(this.router).then(noop)
@@ -68,6 +72,7 @@ export class ProjectPageComponent {
       }),
       finalize(() => {
         if (
+          !this.youtubeIframeUrl &&
           !this.lastData?.lookbooks?.length &&
           !this.lastData?.techMaterialImages?.length &&
           !this.lastData?.designBookImages?.length
@@ -75,6 +80,18 @@ export class ProjectPageComponent {
           displayNotFound(this.router).then(noop)
         }
       }),
+    )
+  }
+
+  public youtubeIframeUrl?: SafeUrl
+
+  public set youtubePlaylistId(playlistId: string) {
+    const youtubeIframeUrl = new URL(
+      'https://www.youtube-nocookie.com/embed?listType=playlist&&loop=true',
+    )
+    youtubeIframeUrl.searchParams.set('list', playlistId)
+    this.youtubeIframeUrl = this.sanitizer.bypassSecurityTrustResourceUrl(
+      youtubeIframeUrl.toString(),
     )
   }
 
@@ -119,6 +136,7 @@ export class ProjectPageComponent {
     private projectLookbooksService: ProjectLookbooksService,
     private projectsImagesService: ProjectImagesService,
     private imageResponsiveBreakpointsService: ImageResponsiveBreakpointsService,
+    private sanitizer: DomSanitizer,
   ) {}
 }
 

--- a/src/app/projects-page/project-item/project-item.ts
+++ b/src/app/projects-page/project-item/project-item.ts
@@ -7,6 +7,7 @@ export interface Project {
   readonly subtitle: string
   readonly quote?: string
   readonly description: string
+  readonly youtubePlaylistId?: string
   //👇 When hasn't been set, CMS doesn't set the property
   //   CMS sets it after though (if adding & removing)
   readonly credits?: readonly Credit[]


### PR DESCRIPTION
Allows embedding videos in a project by specifying a Youtube Playlist. Then, uses Youtube IFrame API to embed the playlist in the detail view of the project. Uses the host that is more privacy-friendly.

## Changes
- Add field in CMS to include a Youtube Playlist ID. Add explanation on how to retrieve it.
- Add field to project item model
- Add property in project page component to set the playlist ID and get the iframe URL. Bypass sanitization
- Style so that it's centered and takes as maximum 100% width
- Include it in list of items to take into account to return a 404