### PR TITLE
chore(scripts): remove temporary omission of lookbooks

### DIFF
--- a/scripts/src/generate-image-lists.mts
+++ b/scripts/src/generate-image-lists.mts
@@ -185,15 +185,6 @@ class ImageListsGenerator {
         } else {
           Log.info('Found %d images', lookbookFileObjects.length)
         }
-        // Temporarily skip old directories
-        if (lookbookFolderObject.name.startsWith('0')) {
-          Log.warn(
-            'Omitting old lookbook with order prefix',
-            lookbookFolderObject.name,
-          )
-          Log.groupEnd()
-          continue
-        }
         lookbooks.push({
           slug: lookbookFolderObject.name,
           images: lookbookFileObjects.map(this.imageAssetFromFileObject),


### PR DESCRIPTION
See #104 for more info. Merge only when that PR has been deployed to production
