### PR TITLE
refactor(projects): use takeUntilDestroyed

### DIFF
--- a/src/app/about-page/social/social.service.ts
+++ b/src/app/about-page/social/social.service.ts
@@ -25,7 +25,6 @@ export class SocialService {
 
   public getMain(author: Author): Social | undefined {
     const socials = this.mapAll(author.social)
-    console.log(author)
     if (author.social?.mainName && this.isSocialName(author.social.mainName)) {
       const mainUsername = author.social[author.social.mainName]
       if (!!mainUsername && mainUsername.length > 0)


### PR DESCRIPTION
Much nicer than unsubscribing manually (and a bit more that `takeUntil(destroyed$)` or other approaches. In developer preview, but looks nice :) 

Extras:
 - Remove `console.log` leftover
 - Add `share` after `concatMap` instead of piping there