### PR TITLE
feat(projects): add assets collections service

### DIFF
--- a/scripts/src/generators.mts
+++ b/scripts/src/generators.mts
@@ -39,6 +39,7 @@ class Generators {
     //await this.projectsImages()
     //await this.projectsList()
     await this.authorsList()
+    await this.assetsCollectionsList()
   }
 
   public async miscImages() {
@@ -84,6 +85,12 @@ class Generators {
       async (resource: Resource) => {
         return { slug: resource.slug }
       },
+    ).generate()
+  }
+
+  public async assetsCollectionsList(): Promise<void> {
+    return new ResourceCollectionListGenerator(
+      new ResourceCollection(join(this.DATA_PATH, 'assets-collections')),
     ).generate()
   }
 }

--- a/scripts/src/imagekit.mts
+++ b/scripts/src/imagekit.mts
@@ -60,7 +60,10 @@ export class Imagekit implements ImageCdnApi {
       Log.groupEnd()
       for (const directoryName of directoryNames) {
         imagesFromDirectories.push(
-          ...(await this.getAllImagesInPath(`${path}/${directoryName}`)),
+          ...(await this.getAllImagesInPath(
+            `${path}/${directoryName}`,
+            includeSubdirectories,
+          )),
         )
       }
     } else {

--- a/scripts/src/resource-images-generator.mts
+++ b/scripts/src/resource-images-generator.mts
@@ -7,6 +7,7 @@ export class ResourceImagesGenerator {
   public async generate(resource: Resource): Promise<void> {
     const images = await this.imageCdnApi.getAllImagesInPath(
       this.getImageCdnPath(resource),
+      true,
     )
     await resource.childCollection.createResource(this.basename, images)
   }

--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -263,7 +263,7 @@ collections:
         hint: 'Will be used when listing assets for a project'
       - <<: *slug
         label: 'Slug (directory name in image CDN)'
-        hint: 'If representing a collection of images, ‼️ MUST match the name of the directory you will use for it inside each project in the image CDN. Otherwise, proper name will not be displayed. 💡 Lookbook specific names are specified per project'
+        hint: 'If representing a collection of images, ‼️ MUST match the name of the directory you will use for it inside each project in the image CDN. Otherwise, proper name will not be displayed. For videos, leave it to "videos" :) 💡 Lookbook specific names are specified per project'
       - label: 'Gallery size'
         name: 'size'
         hint: 'Specifies the size for the gallery when displaying the assets in the project detail page. Full size: will take as much space as possible. This means as much height as possible on big screens or full width on small screens. Half size: assets will take half of width in big screens. On small screens, will keep taking full width'

--- a/src/app/projects/project-page/any-asset-collection.ts
+++ b/src/app/projects/project-page/any-asset-collection.ts
@@ -1,0 +1,4 @@
+import { ImageAssetsCollection } from './image-assets-collection'
+import { VideoAssetsCollection } from './video-assets-collection'
+
+export type AnyAssetsCollection = ImageAssetsCollection | VideoAssetsCollection

--- a/src/app/projects/project-page/assets-collection.ts
+++ b/src/app/projects/project-page/assets-collection.ts
@@ -1,0 +1,5 @@
+export interface AssetsCollection {
+  readonly name: string
+  readonly slug: string
+  readonly size: 'full' | 'half'
+}

--- a/src/app/projects/project-page/image-assets-collection.ts
+++ b/src/app/projects/project-page/image-assets-collection.ts
@@ -1,0 +1,6 @@
+import { ImageAsset } from '../../common/images/image-asset'
+import { AssetsCollection } from './assets-collection'
+
+export interface ImageAssetsCollection extends AssetsCollection {
+  readonly images: ReadonlyArray<ImageAsset>
+}

--- a/src/app/projects/project-page/project-assets-collections.service.spec.ts
+++ b/src/app/projects/project-page/project-assets-collections.service.spec.ts
@@ -1,0 +1,18 @@
+import { TestBed } from '@angular/core/testing'
+
+import { ProjectAssetsCollectionsService } from './project-assets-collections.service'
+import { MockProviders } from 'ng-mocks'
+import { JsonFetcher } from '../../common/json-fetcher/json-fetcher'
+
+describe('ProjectAssetsCollectionsService', () => {
+  let service: ProjectAssetsCollectionsService
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ providers: MockProviders(JsonFetcher) })
+    service = TestBed.inject(ProjectAssetsCollectionsService)
+  })
+
+  it('should be created', () => {
+    expect(service).toBeTruthy()
+  })
+})

--- a/src/app/projects/project-page/project-assets-collections.service.ts
+++ b/src/app/projects/project-page/project-assets-collections.service.ts
@@ -1,0 +1,239 @@
+import { Inject, Injectable, InjectionToken } from '@angular/core'
+import { Project } from '../project'
+import { VideoAssetsCollection } from './video-assets-collection'
+import { YoutubePlaylist } from './youtube-playlist'
+import { from, map, Observable } from 'rxjs'
+import { AnyAssetsCollection } from './any-asset-collection'
+import { AssetsCollection } from './assets-collection'
+import assetsCollectionsJson from '../../../data/assets-collections.json'
+import assetsCollectionsOrderJson from '../../../data/misc/assets-collections-order.json'
+import lookbookCollection from '../../../data/assets-collections/lookbooks.json'
+import videoCollectionJson from '../../../data/assets-collections/videos.json'
+import { ImageAssetsCollection } from './image-assets-collection'
+import { JsonFetcher } from '../../common/json-fetcher/json-fetcher'
+import { PROJECTS_DIR } from '../../common/directories'
+import { ImageAsset } from '../../common/images/image-asset'
+import { ProjectImageAsset } from './project-image-asset'
+import { LookbookNameAndSlug } from '../lookbook-name-and-slug'
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ProjectAssetsCollectionsService {
+  private assetsCollections: ReadonlyArray<AssetsCollection>
+  private orderByCollectionSlug: Map<string, number>
+
+  constructor(
+    @Inject(ASSETS_COLLECTIONS)
+    unsortedAssetsCollections: ReadonlyArray<AssetsCollection>,
+    @Inject(ASSETS_COLLECTIONS_ORDER)
+    assetsCollectionsOrder: typeof assetsCollectionsOrderJson,
+    private jsonFetcher: JsonFetcher,
+    @Inject(VIDEO_ASSETS_COLLECTION)
+    private videoAssetsCollection: AssetsCollection,
+    @Inject(LOOKBOOK_COLLECTION_SLUG) private lookbookCollectionSlug: string,
+  ) {
+    const assetsCollections = []
+    const unsortedAssetsCollectionsBySlug = new Map(
+      unsortedAssetsCollections.map((assetCollection) => [
+        assetCollection.slug,
+        assetCollection,
+      ]),
+    )
+    for (const assetCollectionSlug of assetsCollectionsOrder.assetCollectionsOrder) {
+      const assetCollection =
+        unsortedAssetsCollectionsBySlug.get(assetCollectionSlug)
+      if (assetCollection) {
+        assetsCollections.push(assetCollection)
+        unsortedAssetsCollectionsBySlug.delete(assetCollection.slug)
+      }
+    }
+    this.assetsCollections = [
+      ...assetsCollections,
+      ...unsortedAssetsCollectionsBySlug.values(),
+    ]
+    this.orderByCollectionSlug = new Map(
+      this.assetsCollections.map((assetsCollection, index) => [
+        assetsCollection.slug,
+        index,
+      ]),
+    )
+  }
+
+  byProject(project: Project): Observable<ReadonlyArray<AnyAssetsCollection>> {
+    const videoAssetsCollections = this.getVideoAssetsCollections(project)
+    const imageAssetsCollections = this.getImageAssetsCollections(
+      project.slug,
+      project.lookbookNamesAndSlugs ?? [],
+    )
+    return imageAssetsCollections.pipe(
+      map((imageAssetsCollections) => [
+        ...imageAssetsCollections,
+        ...videoAssetsCollections,
+      ]),
+      map((allCollections) =>
+        allCollections.sort(
+          (a, b) =>
+            (this.orderByCollectionSlug.get(a.slug) ??
+              this.assetsCollections.length) -
+            (this.orderByCollectionSlug.get(b.slug) ??
+              this.assetsCollections.length),
+        ),
+      ),
+    )
+  }
+
+  private getVideoAssetsCollections(
+    project: Project,
+  ): ReadonlyArray<VideoAssetsCollection> {
+    if (!project.youtubePlaylistId) {
+      return []
+    }
+    return [
+      {
+        ...this.videoAssetsCollection,
+        youtubePlaylist: new YoutubePlaylist(project.youtubePlaylistId),
+      },
+    ]
+  }
+
+  private getImageAssetsCollections(
+    slug: string,
+    lookbookNamesAndSlugs: ReadonlyArray<LookbookNameAndSlug>,
+  ): Observable<ReadonlyArray<ImageAssetsCollection>> {
+    return from(
+      this.jsonFetcher.fetch<ReadonlyArray<ImageAsset>>(
+        PROJECTS_DIR,
+        slug,
+        'images.json',
+      ),
+    ).pipe(
+      map((imageAssets) =>
+        this.mapImageAssetsToCollections(
+          imageAssets,
+          slug,
+          lookbookNamesAndSlugs,
+        ),
+      ),
+    )
+  }
+
+  private mapImageAssetsToCollections(
+    imageAssets: ReadonlyArray<ImageAsset>,
+    slug: string,
+    lookbookNamesAndSlugs: ReadonlyArray<LookbookNameAndSlug>,
+  ): ReadonlyArray<ImageAssetsCollection> {
+    const projectImageAssets = imageAssets.map(
+      (imageAsset) => new ProjectImageAsset(imageAsset, slug),
+    )
+    const projectImageAssetsByCollectionSlug = new Map<
+      string,
+      ReadonlyArray<ProjectImageAsset>
+    >()
+    for (const projectImageAsset of projectImageAssets) {
+      const collection = projectImageAsset.collection
+      const assetsInCollection =
+        projectImageAssetsByCollectionSlug.get(collection) ?? []
+      projectImageAssetsByCollectionSlug.set(collection, [
+        ...assetsInCollection,
+        projectImageAsset,
+      ])
+    }
+    const assetCollections: ImageAssetsCollection[] = []
+    for (const assetCollection of this.assetsCollections) {
+      const projectImageAssets = projectImageAssetsByCollectionSlug.get(
+        assetCollection.slug,
+      )
+      if (projectImageAssets && projectImageAssets.length > 0) {
+        if (assetCollection.slug === this.lookbookCollectionSlug) {
+          const projectImageAssetsBySubcollectionSlug = new Map<
+            string,
+            ReadonlyArray<ProjectImageAsset>
+          >()
+          for (const projectImageAsset of projectImageAssets) {
+            const subcollection = projectImageAsset.subCollection
+            const assetsInCollection =
+              projectImageAssetsBySubcollectionSlug.get(subcollection) ?? []
+            projectImageAssetsBySubcollectionSlug.set(subcollection, [
+              ...assetsInCollection,
+              projectImageAsset,
+            ])
+          }
+          const lookbookCollections: ImageAssetsCollection[] = []
+          let index = 1
+          for (const lookbookNameAndSlug of lookbookNamesAndSlugs) {
+            const subcollectionImageAssets =
+              projectImageAssetsBySubcollectionSlug.get(
+                lookbookNameAndSlug.slug,
+              )
+            if (
+              subcollectionImageAssets &&
+              subcollectionImageAssets.length > 0
+            ) {
+              lookbookCollections.push({
+                ...assetCollection,
+                name: `${assetCollection.name} ${index} "${lookbookNameAndSlug.name}"`,
+                images: subcollectionImageAssets.map(({ asset }) => asset),
+              })
+              projectImageAssetsBySubcollectionSlug.delete(
+                lookbookNameAndSlug.slug,
+              )
+              index++
+            }
+          }
+          const restOfLookbookImages = Array.from(
+            projectImageAssetsBySubcollectionSlug.values(),
+          )
+            .flat()
+            .map(({ asset }) => asset)
+          if (restOfLookbookImages.length > 0) {
+            lookbookCollections.push({
+              ...assetCollection,
+              name: `${assetCollection.name} ${index}`,
+              images: restOfLookbookImages,
+            })
+          }
+          assetCollections.push(...lookbookCollections)
+          projectImageAssetsByCollectionSlug.delete(assetCollection.slug)
+        } else {
+          assetCollections.push({
+            ...assetCollection,
+            images: projectImageAssets.map(({ asset }) => asset),
+          })
+          projectImageAssetsByCollectionSlug.delete(assetCollection.slug)
+        }
+      }
+    }
+    const restOfImages = Array.from(projectImageAssetsByCollectionSlug.values())
+      .flat()
+      .map(({ asset }) => asset)
+    if (restOfImages.length > 0) {
+      assetCollections.push({
+        name: 'Other images',
+        slug: 'other',
+        size: 'full',
+        images: restOfImages,
+      })
+    }
+    return assetCollections
+  }
+}
+
+const ASSETS_COLLECTIONS = new InjectionToken<ReadonlyArray<AssetsCollection>>(
+  'Assets collections',
+  { factory: () => assetsCollectionsJson as ReadonlyArray<AssetsCollection> },
+)
+
+const ASSETS_COLLECTIONS_ORDER = new InjectionToken<
+  typeof assetsCollectionsOrderJson
+>('Assets collections order', { factory: () => assetsCollectionsOrderJson })
+
+const VIDEO_ASSETS_COLLECTION = new InjectionToken<AssetsCollection>(
+  'Video assets collection',
+  { factory: () => videoCollectionJson as AssetsCollection },
+)
+
+const LOOKBOOK_COLLECTION_SLUG = new InjectionToken<string>(
+  'Lookbooks assets collections slug',
+  { factory: () => lookbookCollection.slug },
+)

--- a/src/app/projects/project-page/project-image-asset.ts
+++ b/src/app/projects/project-page/project-image-asset.ts
@@ -1,0 +1,37 @@
+import { ImageAsset } from '../../common/images/image-asset'
+import { PROJECTS_DIR } from '../../common/directories'
+
+export class ProjectImageAsset {
+  private _relativeFilePath?: string
+
+  constructor(
+    public readonly asset: ImageAsset,
+    private readonly projectSlug: string,
+  ) {}
+
+  public get collection(): string {
+    const relativeFilePathParts = this.relativeFilePath.split('/')
+    if (relativeFilePathParts.length < 2) {
+      return ''
+    }
+    return relativeFilePathParts[0]
+  }
+
+  public get subCollection(): string {
+    const relativeFilePathParts = this.relativeFilePath.split('/')
+    if (relativeFilePathParts.length < 3) {
+      return ''
+    }
+    return relativeFilePathParts[1]
+  }
+
+  public get relativeFilePath() {
+    if (!this._relativeFilePath) {
+      this._relativeFilePath = this.asset.filePath
+        .replace(/^\//, '')
+        .replace(new RegExp(`^${PROJECTS_DIR}/`), '')
+        .replace(new RegExp(`^${this.projectSlug}/`), '')
+    }
+    return this._relativeFilePath
+  }
+}

--- a/src/app/projects/project-page/project-page.component.ts
+++ b/src/app/projects/project-page/project-page.component.ts
@@ -1,6 +1,5 @@
 import { Component, DestroyRef, Input } from '@angular/core'
 import { ProjectsService } from '../projects.service'
-import { Router } from '@angular/router'
 import {
   catchError,
   combineLatest,
@@ -72,7 +71,6 @@ export class ProjectPageComponent {
   constructor(
     private projectsService: ProjectsService,
     private navigatorService: NavigatorService,
-    private router: Router,
     private seo: SeoService,
     private projectLookbooksService: ProjectLookbooksService,
     private projectsImagesService: ProjectImagesService,

--- a/src/app/projects/project-page/video-assets-collection.ts
+++ b/src/app/projects/project-page/video-assets-collection.ts
@@ -1,0 +1,6 @@
+import { YoutubePlaylist } from './youtube-playlist'
+import { AssetsCollection } from './assets-collection'
+
+export interface VideoAssetsCollection extends AssetsCollection {
+  readonly youtubePlaylist: YoutubePlaylist
+}

--- a/src/data/assets-collections/tech-materials.json
+++ b/src/data/assets-collections/tech-materials.json
@@ -1,5 +1,5 @@
 {
   "name": "Tech material",
-  "slug": "tech-materials",
+  "slug": "tech-material",
   "size": "half"
 }

--- a/src/data/misc/assets-collections-order.json
+++ b/src/data/misc/assets-collections-order.json
@@ -2,7 +2,7 @@
   "assetCollectionsOrder": [
     "videos",
     "lookbooks",
-    "tech-materials",
+    "tech-material",
     "design-book",
     "concept"
   ]


### PR DESCRIPTION
Uses asset collections from CMS to generate asset collections names and their order

Also:
 - Remove unneeded router in project page
 - Enable recursion when listing all images
 - Fix wrong directory name / slug for tech images collection
