### PR TITLE
refactor(script): add preview asset dir and use it in script

### DIFF
--- a/.idea/runConfigurations/Generate.xml
+++ b/.idea/runConfigurations/Generate.xml
@@ -3,7 +3,7 @@
     <package-json value="$PROJECT_DIR$/package.json" />
     <command value="run" />
     <scripts>
-      <script value="generators" />
+      <script value="generate" />
     </scripts>
     <node-interpreter value="project" />
     <envs />

--- a/scripts/src/generators.mts
+++ b/scripts/src/generators.mts
@@ -12,7 +12,9 @@ import { ProjectListItemExtraDataGenerator } from './project-list-item-extra-dat
 import { Resource } from './resource.mjs'
 import { MiscImages } from '../../src/app/common/images/misc-images.js'
 import { RoutesFileGenerator } from './routes-file-generator.mjs'
+import filesPkg from '../../src/app/common/files.js'
 
+const { IMAGES_FILE_BASENAME } = filesPkg
 const { DATA_DIR, CONTENTS_DIR, PROJECTS_DIR } = directoriesPkg
 
 class Generators {
@@ -63,7 +65,7 @@ class Generators {
       horizontalLogo,
       aboutPortrait,
     }
-    await this.misc.upsertResource('images', miscImages)
+    await this.misc.upsertResource(IMAGES_FILE_BASENAME, miscImages)
   }
 
   public async projectsImages() {

--- a/scripts/src/project-list-item-extra-data-generator.mts
+++ b/scripts/src/project-list-item-extra-data-generator.mts
@@ -4,9 +4,10 @@ import { ResourceImagesGenerator } from './resource-images-generator.mjs'
 import { ListItemExtraData } from '../../src/app/projects/project-list-item.js'
 import { Log } from './log.mjs'
 import { Project } from '../../src/app/projects/project.js'
+import previewJson from '../../src/data/assets-collections/preview.json' assert { type: 'json' }
 
 export class ProjectListItemExtraDataGenerator {
-  private readonly PREVIEW_IMAGES_DIRECTORY = 'preview'
+  private readonly PREVIEW_IMAGES_DIRECTORY = previewJson.slug
   private _imagesResource?: Resource | null
   private _imagesByGroups?: ImagesByGroups
 

--- a/scripts/src/resource-images-generator.mts
+++ b/scripts/src/resource-images-generator.mts
@@ -1,5 +1,8 @@
 import { Resource } from './resource.mjs'
 import { ImageCdnApi } from './image-cdn-api.mjs'
+import filesPkg from '../../src/app/common/files.js'
+
+const { IMAGES_FILE_BASENAME } = filesPkg
 
 export class ResourceImagesGenerator {
   constructor(public readonly imageCdnApi: ImageCdnApi) {}
@@ -17,6 +20,6 @@ export class ResourceImagesGenerator {
   }
 
   public get basename() {
-    return 'images'
+    return IMAGES_FILE_BASENAME
   }
 }

--- a/src/app/common/directories.ts
+++ b/src/app/common/directories.ts
@@ -1,3 +1,5 @@
+// 👇 Used by script, despite marked unused by IDE
 export const DATA_DIR = 'data'
 export const CONTENTS_DIR = 'content'
+// Must match directory name here and in the images CDN (for scripts to work)
 export const PROJECTS_DIR = 'projects'

--- a/src/app/common/files.ts
+++ b/src/app/common/files.ts
@@ -2,17 +2,9 @@ export function getListFilename(directory: string) {
   return addJsonExtension(directory)
 }
 
-export function getImagesFilename(name: string) {
-  return addJsonExtension(`${name}-images`)
-}
-
 export function addJsonExtension(filename: string): string {
   return `${filename}.json`
 }
 
-//👇 Actually used by scripts
-export const PREVIEW_IMAGES_FILENAME = getImagesFilename('preview')
-export const LOOKBOOKS_IMAGES_FILENAME = getImagesFilename('lookbooks')
-export const TECH_MATERIAL_IMAGES_FILENAME = getImagesFilename('tech-material')
-export const DESIGN_BOOK_IMAGES_FILENAME = getImagesFilename('design-book')
-export const CONCEPT_IMAGES_FILENAME = getImagesFilename('concept')
+export const IMAGES_FILE_BASENAME = 'images'
+export const IMAGES_FILENAME = addJsonExtension(IMAGES_FILE_BASENAME)

--- a/src/app/projects/project-page/project-assets-collections.service.ts
+++ b/src/app/projects/project-page/project-assets-collections.service.ts
@@ -16,6 +16,7 @@ import { ImageAsset } from '../../common/images/image-asset'
 import { ProjectImageAsset } from './project-image-asset'
 import { LookbookNameAndSlug } from '../lookbook-name-and-slug'
 import { AssetsCollectionSize } from './assets-collection-size'
+import { IMAGES_FILENAME } from '../../common/files'
 
 @Injectable({
   providedIn: 'root',
@@ -107,7 +108,7 @@ export class ProjectAssetsCollectionsService {
       this.jsonFetcher.fetch<ReadonlyArray<ImageAsset>>(
         PROJECTS_DIR,
         slug,
-        'images.json',
+        IMAGES_FILENAME,
       ),
     ).pipe(
       map((imageAssets) =>

--- a/src/data/assets-collections/preview.json
+++ b/src/data/assets-collections/preview.json
@@ -1,0 +1,5 @@
+{
+  "name": "Preview",
+  "slug": "preview",
+  "size": "full"
+}


### PR DESCRIPTION
Adds preview as asset collection. Uses it in generator script to match slug name.

Removes no longer used filename constants
Adds constant to refer to image filename