### PR TITLE
build: use specific swiper modules

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -54,7 +54,14 @@
             "stylePreprocessorOptions": {
               "includePaths": ["src/sass"]
             },
-            "styles": ["src/styles.scss"],
+            "styles": [
+              "src/styles.scss",
+              {
+                "input": "src/swiper.scss",
+                "inject": false,
+                "bundleName": "swiper"
+              }
+            ],
             "scripts": []
           },
           "configurations": {
@@ -123,7 +130,14 @@
             "stylePreprocessorOptions": {
               "includePaths": ["src/sass"]
             },
-            "styles": ["src/styles.scss"],
+            "styles": [
+              "src/styles.scss",
+              {
+                "input": "src/swiper.scss",
+                "inject": false,
+                "bundleName": "swiper"
+              }
+            ],
             "scripts": []
           }
         },

--- a/src/app/projects/images-swiper/images-swiper.component.scss
+++ b/src/app/projects/images-swiper/images-swiper.component.scss
@@ -1,4 +1,4 @@
-@use '../../../sass/theme';
+@use 'theme';
 
 :host {
   swiper-container {

--- a/src/app/projects/images-swiper/images-swiper.component.ts
+++ b/src/app/projects/images-swiper/images-swiper.component.ts
@@ -8,7 +8,6 @@ import {
   A11y,
   Autoplay,
   Keyboard,
-  Mousewheel,
   Navigation,
   Pagination,
 } from 'swiper/modules'
@@ -30,7 +29,7 @@ export class ImagesSwiperComponent implements OnChanges {
   @Input() public customSwiperOptions?: SwiperOptions
   protected readonly DEFAULT_IMAGE_ALT = DEFAULT_ALT
   protected readonly DEFAULT_SWIPER_OPTIONS: SwiperOptions = {
-    modules: [A11y, Autoplay, Keyboard, Mousewheel, Navigation, Pagination],
+    modules: [A11y, Autoplay, Keyboard, Navigation, Pagination],
     injectStylesUrls: ['/swiper.css'],
     a11y: {
       enabled: false,
@@ -41,9 +40,6 @@ export class ImagesSwiperComponent implements OnChanges {
     },
     keyboard: {
       enabled: true,
-    },
-    mousewheel: {
-      forceToAxis: true,
     },
     navigation: {
       enabled: true,

--- a/src/app/projects/images-swiper/images-swiper.component.ts
+++ b/src/app/projects/images-swiper/images-swiper.component.ts
@@ -1,7 +1,21 @@
 import { Component, Input, OnChanges } from '@angular/core'
+import { register as registerSwiper } from 'swiper/element'
+
 import { DEFAULT_ALT } from '../../common/images/default-alt'
 import { SwiperOptions } from 'swiper/types'
 import { ImageAsset } from '../../common/images/image-asset'
+import {
+  A11y,
+  Autoplay,
+  Keyboard,
+  Mousewheel,
+  Navigation,
+  Pagination,
+} from 'swiper/modules'
+
+// There's no fancier way to install Web Components in Angular :P
+// https://stackoverflow.com/a/75353889/3263250
+registerSwiper()
 
 @Component({
   selector: 'app-images-swiper',
@@ -16,20 +30,28 @@ export class ImagesSwiperComponent implements OnChanges {
   @Input() public customSwiperOptions?: SwiperOptions
   protected readonly DEFAULT_IMAGE_ALT = DEFAULT_ALT
   protected readonly DEFAULT_SWIPER_OPTIONS: SwiperOptions = {
-    pagination: {
-      enabled: true,
-      clickable: true,
-      dynamicBullets: true,
-    },
-    navigation: {
-      enabled: true,
-    },
-    keyboard: {
-      enabled: true,
+    modules: [A11y, Autoplay, Keyboard, Mousewheel, Navigation, Pagination],
+    injectStylesUrls: ['/swiper.css'],
+    a11y: {
+      enabled: false,
     },
     autoplay: {
       disableOnInteraction: true,
       delay: 2500,
+    },
+    keyboard: {
+      enabled: true,
+    },
+    mousewheel: {
+      forceToAxis: true,
+    },
+    navigation: {
+      enabled: true,
+    },
+    pagination: {
+      enabled: true,
+      clickable: true,
+      dynamicBullets: true,
     },
   }
   protected _maxSlidesPerView: number | null = null

--- a/src/app/projects/images-swiper/swiper.directive.spec.ts
+++ b/src/app/projects/images-swiper/swiper.directive.spec.ts
@@ -20,8 +20,6 @@ import { MockProvider } from 'ng-mocks'
 
 describe('SwiperDirective', () => {
   const options: SwiperOptions = {
-    autoplay: true,
-    loop: true,
     breakpoints: {
       640: {
         slidesPerView: 2,
@@ -111,7 +109,7 @@ function makeComponentWithDirective({
 
   @Component({
     template: ` <!--suppress AngularUndefinedBinding -->
-        <${SWIPER_ELEMENT_TAG} [appSwiper]="options"></${SWIPER_ELEMENT_TAG}>`,
+    <${SWIPER_ELEMENT_TAG} [appSwiper]="options"></${SWIPER_ELEMENT_TAG}>`,
   })
   class SwiperComponent implements OnInit {
     public readonly options = options

--- a/src/app/projects/images-swiper/swiper.directive.ts
+++ b/src/app/projects/images-swiper/swiper.directive.ts
@@ -17,7 +17,7 @@ export class SwiperDirective implements AfterViewInit {
   @Input('appSwiper')
   options?: SwiperOptions
 
-  public container: SwiperContainer
+  public readonly container: SwiperContainer
 
   constructor(
     private el: ElementRef<HTMLElement>,

--- a/src/app/projects/projects.module.ts
+++ b/src/app/projects/projects.module.ts
@@ -1,21 +1,15 @@
 import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core'
 import { CommonModule, NgOptimizedImage } from '@angular/common'
+import { RouterModule } from '@angular/router'
 
 import { SwiperDirective } from './images-swiper/swiper.directive'
 import { ImagesSwiperComponent } from './images-swiper/images-swiper.component'
 import { ProjectsPageComponent } from './projects-page/projects-page.component'
 import { ProjectListItemComponent } from './projects-page/project-list-item/project-list-item.component'
 import { ProjectPageComponent } from './project-page/project-page.component'
-import { RouterModule } from '@angular/router'
 import { SanitizeResourceUrlPipe } from './sanitize-resource-url.pipe'
-
-import { register as registerSwiper } from 'swiper/element/bundle'
 import { ProjectsService } from './projects.service'
 import { ProjectAssetsCollectionsService } from './project-page/project-assets-collections.service'
-
-// There's no fancier way to install Web Components in Angular :P
-// https://stackoverflow.com/a/75353889/3263250
-registerSwiper()
 
 @NgModule({
   declarations: [

--- a/src/swiper.scss
+++ b/src/swiper.scss
@@ -5,8 +5,6 @@
 //noinspection CssUnknownTarget
 @import 'swiper/element/css/keyboard';
 //noinspection CssUnknownTarget
-@import 'swiper/element/css/mousewheel';
-//noinspection CssUnknownTarget
 @import 'swiper/element/css/navigation';
 //noinspection CssUnknownTarget
 @import 'swiper/element/css/pagination';

--- a/src/swiper.scss
+++ b/src/swiper.scss
@@ -1,0 +1,12 @@
+//noinspection CssUnknownTarget
+@import 'swiper/element/css/a11y';
+//noinspection CssUnknownTarget
+@import 'swiper/element/css/autoplay';
+//noinspection CssUnknownTarget
+@import 'swiper/element/css/keyboard';
+//noinspection CssUnknownTarget
+@import 'swiper/element/css/mousewheel';
+//noinspection CssUnknownTarget
+@import 'swiper/element/css/navigation';
+//noinspection CssUnknownTarget
+@import 'swiper/element/css/pagination';


### PR DESCRIPTION
To save some KBs in main bundle

## Changes
- Follow [docs to register core & import specific modules](https://swiperjs.com/element#core-version--modules)
- Emit `swiper.css` with Angular to include it as swiper styles
- Enable a11y & mousewheel modules
- Move `register` call from module to component (where we actually use the swiper)
- Sort default swiper options, so modules & options are in same, alphabetical order (easier to check we've included them all)

## Tried
- Adding mousewheel module. But [fails Lighthouse check](https://github.com/davidlj95/chrislb/actions/runs/6764474829/job/18382820874) [about passive event listeners](https://developer.chrome.com/docs/lighthouse/best-practices/uses-passive-event-listeners/)

## Wins
527KB -> 460: 67KB! 

[main.before.pdf](https://github.com/davidlj95/chrislb/files/13261171/main.before.pdf)
[main.after.pdf](https://github.com/davidlj95/chrislb/files/13261188/main.after.pdf)
