### PR TITLE
feat(images): point to specific version

### DIFF
--- a/docs/content-management/index.md
+++ b/docs/content-management/index.md
@@ -223,13 +223,13 @@ When you upload new images, those won't appear immediately, you'll need to chang
 fetched as part of the website build (see [side effects]). And then, new images will appear if they have been placed
 properly (see [linking images])
 
-### Uploading / overwriting existing images
+### Updating images
 
-If you upload an image with same name, it will override the existing image.
+If you upload an image with same name, the CDN [will add a new version for that image][asset-versioning]. However, the change will not immediately appear in the website, because when the website is built, images are pointed to a specific version. You'll need to generate a new website version for the new image version to appear (see [side effects]).
 
-⚠️ **Change will be published immediately to main website**
+To look for image versions in the CDN, [check their asset versioning documentation][asset-versioning]
 
-> ⚙️ **Work in progress** exists to remediate this behavior
+[asset-versioning]: https://docs.imagekit.io/media-library/overview/asset-versioning
 
 ### Removing images
 

--- a/scripts/src/imagekit.mts
+++ b/scripts/src/imagekit.mts
@@ -6,6 +6,7 @@ import imagesCdnConfigPkg from '../../src/app/common/images/cdn-config.js'
 import { FileObject, ImageKitOptions } from 'imagekit/dist/libs/interfaces'
 import { ImageAsset } from '../../src/app/common/images/image-asset.js'
 import { ImageCdnApi } from './image-cdn-api.mjs'
+import { URLSearchParams } from 'url'
 
 const { IMAGEKIT_URL } = imagesCdnConfigPkg
 
@@ -110,13 +111,18 @@ export class Imagekit implements ImageCdnApi {
     if (!!alt && alt.length > 0) {
       altMetadata.alt = alt
     }
+    // Point to specific file version
+    const queryParams = new URLSearchParams()
+    queryParams.set(
+      'updatedAt',
+      new Date(fileObject.updatedAt).getTime().toString(),
+    )
     return {
       name: fileObject.name,
       //👇 Needed as otherwise srcSet attribute doesn't work if URL has spaces
-      filePath: fileObject.filePath
-        .split('/')
-        .map(encodeURIComponent)
-        .join('/'),
+      filePath:
+        fileObject.filePath.split('/').map(encodeURIComponent).join('/') +
+        `?${queryParams.toString()}`,
       height: fileObject.height,
       width: fileObject.width,
       ...altMetadata,


### PR DESCRIPTION
This way a new website build is needed to update images. Updating an image in the CDN will result in a new version, but the image on production will keep the same until a new production deploy happens
