### PR TITLE
refactor(images): add responsive image service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@fortawesome/free-solid-svg-icons": "^6.4.2",
         "@ngaox/seo": "^5.0.0",
         "@nguniversal/express-engine": "^16.2.0",
+        "@unpic/core": "^0.0.35",
         "compression": "^1.7.4",
         "express": "^4.15.2",
         "gardevoir": "^1.0.0",
@@ -4648,6 +4649,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@unpic/core": {
+      "version": "0.0.35",
+      "resolved": "https://registry.npmjs.org/@unpic/core/-/core-0.0.35.tgz",
+      "integrity": "sha512-bBJUtRxT1zeBbW8aJWJO9509V+DGGVt9jQhn9wQWWYok+mUHgtSnVeDiGTGhpo2SogB+QgG8hr114TdMkpA7TQ==",
+      "dependencies": {
+        "unpic": "^3.12.0"
       }
     },
     "node_modules/@vitejs/plugin-basic-ssl": {
@@ -15427,6 +15436,11 @@
       "engines": {
         "node": ">= 4.0.0"
       }
+    },
+    "node_modules/unpic": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/unpic/-/unpic-3.12.0.tgz",
+      "integrity": "sha512-dmp0XRBeE6i+wWlWAkF7ordJYi5y7neEGSNvlM+92HUp1VnLUb37NVUZI6AZgb2Rf/vZynSadZkdGbPGXc/ZIA=="
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.4.2",
     "@ngaox/seo": "^5.0.0",
     "@nguniversal/express-engine": "^16.2.0",
+    "@unpic/core": "^0.0.35",
     "compression": "^1.7.4",
     "express": "^4.15.2",
     "gardevoir": "^1.0.0",

--- a/src/app/common/images/responsive-image-attributes.service.spec.ts
+++ b/src/app/common/images/responsive-image-attributes.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing'
+
+import { ResponsiveImageAttributesService } from './responsive-image-attributes.service'
+
+describe('ResponsiveImageService', () => {
+  let service: ResponsiveImageAttributesService
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({})
+    service = TestBed.inject(ResponsiveImageAttributesService)
+  })
+
+  it('should be created', () => {
+    expect(service).toBeTruthy()
+  })
+})

--- a/src/app/common/images/responsive-image-attributes.service.ts
+++ b/src/app/common/images/responsive-image-attributes.service.ts
@@ -1,0 +1,34 @@
+import { Injectable } from '@angular/core'
+import { ResponsiveImageAttributes } from './responsive-image-attributes'
+import { getBreakpoints } from '@unpic/core'
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ResponsiveImageAttributesService {
+  /**
+   * Returns responsive image attributes for an image constrained in size
+   *
+   * Inspired from unpic lib. Can't use that lib because they don't support ImageKit
+   * It's noted to contribute when have some time!
+   *
+   * Supports images that don't take full screen when on small screens (unlike unpic)
+   *
+   * @see https://github.com/ascorbic/unpic-img/blob/core-v0.0.35/packages/core/src/core.ts#L315-L348
+   */
+  public constrained({
+    minWidthVw = 100,
+    maxWidthPx,
+  }: {
+    minWidthVw?: number
+    maxWidthPx: number
+  }): ResponsiveImageAttributes {
+    const maxWidthPxInt = Math.ceil(maxWidthPx)
+    const breakpoints = getBreakpoints({
+      width: maxWidthPxInt,
+      layout: 'constrained',
+    })
+    const sizes = `(min-width: ${maxWidthPxInt}px) ${maxWidthPxInt}px, ${minWidthVw}vw`
+    return ResponsiveImageAttributes.fromBreakpointsAndSizes(breakpoints, sizes)
+  }
+}

--- a/src/app/common/images/responsive-image-attributes.ts
+++ b/src/app/common/images/responsive-image-attributes.ts
@@ -1,0 +1,16 @@
+export class ResponsiveImageAttributes {
+  constructor(
+    public readonly ngSrcSet: string,
+    public readonly sizes: string,
+  ) {}
+
+  static fromBreakpointsAndSizes(
+    pxBreakpoints: ReadonlyArray<number>,
+    sizes: string,
+  ) {
+    return new this(
+      pxBreakpoints.map((pxBreakpoint) => `${pxBreakpoint}w`).join(', '),
+      sizes,
+    )
+  }
+}

--- a/src/app/common/images/responsive-image.ts
+++ b/src/app/common/images/responsive-image.ts
@@ -1,0 +1,9 @@
+import { ImageAsset } from './image-asset'
+import { ResponsiveImageAttributes } from './responsive-image-attributes'
+
+export class ResponsiveImage {
+  constructor(
+    public readonly asset: ImageAsset,
+    public readonly attributes: ResponsiveImageAttributes,
+  ) {}
+}

--- a/src/app/logo/logo.component.html
+++ b/src/app/logo/logo.component.html
@@ -1,11 +1,11 @@
 <a routerLink="/">
   <img
-    [ngSrc]="horizontalLogo.filePath"
-    [alt]="horizontalLogo.alt"
-    [width]="horizontalLogo.width"
-    [height]="horizontalLogo.height"
+    [ngSrc]="horizontalLogo.asset.filePath"
+    [alt]="horizontalLogo.asset.alt"
+    [width]="horizontalLogo.asset.width"
+    [height]="horizontalLogo.asset.height"
     [priority]="true"
-    [ngSrcset]="srcSet"
-    [sizes]="sizes"
+    [ngSrcset]="horizontalLogo.attributes.ngSrcSet"
+    [sizes]="horizontalLogo.attributes.sizes"
   />
 </a>

--- a/src/app/logo/logo.component.scss
+++ b/src/app/logo/logo.component.scss
@@ -19,6 +19,7 @@
   padding: logo.$padding-vertical page.$padding-horizontal;
 
   img {
+    // Keep in sync with component for responsive sizing!
     max-height: logo.$height-image;
     width: auto;
   }

--- a/src/app/logo/logo.component.ts
+++ b/src/app/logo/logo.component.ts
@@ -1,8 +1,7 @@
 import { Component, Inject } from '@angular/core'
-import { ImageResponsiveBreakpointsService } from '../common/images/image-responsive-breakpoints.service'
-import { ImageResponsiveBreakpoints } from '../common/images/image-responsive-breakpoints'
 import { MISC_IMAGES, MiscImages } from '../common/images/misc-images'
-import { ImageAsset } from '../common/images/image-asset'
+import { ResponsiveImage } from '../common/images/responsive-image'
+import { ResponsiveImageAttributesService } from '../common/images/responsive-image-attributes.service'
 
 @Component({
   selector: 'app-logo',
@@ -10,23 +9,20 @@ import { ImageAsset } from '../common/images/image-asset'
   styleUrls: ['./logo.component.scss'],
 })
 export class LogoComponent {
-  // 👇 Those 2 obtained using https://ausi.github.io/respimagelint/
-  protected readonly LOGO_MAX_WIDTH_PX = 674
-  protected readonly sizes = `${this.LOGO_MAX_WIDTH_PX}px, 92.27vw`
-  protected readonly srcSet = new ImageResponsiveBreakpoints(
-    this.imageResponsiveBreakpointsService
-      .range(
-        this.imageResponsiveBreakpointsService.MIN_SCREEN_WIDTH_PX,
-        this.LOGO_MAX_WIDTH_PX,
-      )
-      .pxValues.concat(this.LOGO_MAX_WIDTH_PX),
-  ).toSrcSet()
-  protected readonly horizontalLogo: ImageAsset
+  protected readonly horizontalLogo: ResponsiveImage
+  // 👇 Keep in sync with SCSS for responsive sizing
+  protected readonly LOGO_MAX_HEIGHT_PX = 100
 
   constructor(
     @Inject(MISC_IMAGES) miscImages: MiscImages,
-    private imageResponsiveBreakpointsService: ImageResponsiveBreakpointsService,
+    responsiveImageAttributesService: ResponsiveImageAttributesService,
   ) {
-    this.horizontalLogo = miscImages.horizontalLogo
+    const horizontalLogoAsset = miscImages.horizontalLogo
+    const aspectRatio = horizontalLogoAsset.width / horizontalLogoAsset.height
+    const maxWidthPx = aspectRatio * this.LOGO_MAX_HEIGHT_PX
+    this.horizontalLogo = new ResponsiveImage(
+      miscImages.horizontalLogo,
+      responsiveImageAttributesService.constrained({ maxWidthPx }),
+    )
   }
 }


### PR DESCRIPTION
Current responsive image breakpoints service can be improved (issues not sorted by relevance):
 1. Name is too long 😛 
 2. `srcSet` property is not actually a `srcSet`, but something to be used inside `ngSrcSet`. 
 3. `sizes` is set by consumer, in a component instance property
 4. When generating breakpoints, if image is constrained to a certain width, the width is not included in breakpoints. Which means the consumer has to create a new breakpoint set including that width.
 5. Breakpoints do not take into account high density screens (discovered this thanks to [discovering `unpic`](https://www.youtube.com/watch?v=6qSeGmK3dMk))

Visual example:
https://github.com/davidlj95/chrislb/blob/7205471913f49e6973991c71ddf020cc8f296169/src/app/logo/logo.component.ts#L14-L23

So in order to solve that:
 1. Reducing name to `ResponsiveImageAttributesService`. 1 char less 🎉 😆 
 2. Renamed to `ngSrcSet`
 3. Added model `ResponsiveImageAttributes`, so both `ngSrcSet` and `sizes` are hold together
 4. Using `@unpic/core` for breakpoints generation. Which takes into account width and double width for next point.
 5. `@unpic/core` takes into account high density by including in breakpoints until double max width to take into account 2x px density
 
Plus
 1. Adding `ResponsiveImage` to hold an `ImageAsset` with `ResponsiveImageAttributes` and group everything needed to use an image with `NgOptimizedImage` all together

PD: thanks to @ascorbic for the `unpic` lib 👏  `// TODO: Contribute to unpic lib adding ImageKit CDN to use unpic-img / @unpic/angular`