### PR TITLE
feat(cms): fix slug issue with author + move OG profile

### DIFF
--- a/src/admin/config.yml
+++ b/src/admin/config.yml
@@ -182,9 +182,9 @@ collections:
             name: 'authorSlug'
             widget: 'relation'
             collection: 'authors'
-            search_fields: ['name', 'social.instagram']
+            search_fields: ['name']
             value_field: '{{slug}}'
-            display_fields: ['{{name}} ({{social.instagram}})']
+            display_fields: ['{{name}}']
   - name: 'authors'
     label: 'Authors'
     label_singular: 'author'
@@ -194,31 +194,16 @@ collections:
     create: true
     slug: '{{slug}}'
     identifier_field: 'name'
-    summary: '{{firstName}} {{lastName}}'
+    summary: '{{name}}'
     fields:
-      - label: 'First name'
-        name: 'firstName'
-        widget: 'string'
-      - label: 'Last name'
-        name: 'lastName'
-        widget: 'string'
-      - label: 'Gender'
-        widget: 'select'
-        name: 'gender'
-        required: false
-        hint: 'Will only be used for main website author metadata. Unfortunately specification only accepts male or female 😬 . More info: https://ogp.me/#type_profile'
-        options:
-          - label: 'Male'
-            value: 'male'
-          - label: 'Female'
-            value: 'female'
+      - *name
       - label: 'Social'
         name: 'social'
         widget: 'object'
         fields:
-          - label: 'Main social network'
-            name: 'mainName'
-            hint: 'Will be used in credits. If unset, defaults to default social network preference (currently being first Instagram, then LinkedIn or finally TikTok)'
+          - label: 'Preferred social network'
+            name: 'preferred'
+            hint: 'Will be used in credits. If unset, defaults to default social network preference (see here: https://github.com/davidlj95/chrislb/blob/main/src/app/common/social/social.service.ts#L16-L18)'
             required: false
             widget: 'select'
             options:
@@ -228,11 +213,6 @@ collections:
                 value: 'linkedin'
               - label: 'TikTok'
                 value: 'tiktok'
-          - <<: *username
-            label: 'Main username'
-            name: 'mainUsername'
-            required: false
-            hint: 'Will only be used for main website author metadata. More info: https://ogp.me/#type_profile'
           - <<: *username
             label: 'Instagram'
             name: 'instagram'
@@ -299,6 +279,31 @@ collections:
           - label: 'Text'
             name: 'text'
             widget: 'text'
+          - label: 'Open Graph profile'
+            name: 'openGraphProfile'
+            widget: 'object'
+            hint: 'Will be used as metadata to describe this page represents this person on the Internet. More info: https://ogp.me/#type_profile'
+            fields:
+              - label: 'First name'
+                name: 'firstName'
+                widget: 'string'
+              - label: 'Last name'
+                name: 'lastName'
+                widget: 'string'
+              - label: 'Gender'
+                widget: 'select'
+                name: 'gender'
+                required: false
+                hint: 'Will only be used for main website author metadata. Unfortunately specification only accepts male or female 😬'
+                options:
+                  - label: 'Male'
+                    value: 'male'
+                  - label: 'Female'
+                    value: 'female'
+              - <<: *username
+                label: 'Main username'
+                name: 'username'
+                required: false
           - label: 'Resume'
             name: 'resume'
             widget: 'list'

--- a/src/app/about-page/about-page-routing.module.ts
+++ b/src/app/about-page/about-page-routing.module.ts
@@ -2,9 +2,9 @@ import { NgModule } from '@angular/core'
 import { RouterModule } from '@angular/router'
 import { AboutPageComponent } from './about-page.component'
 import aboutPageMetadata from '../../data/pages/about.json'
-import christianLazaro from '../../data/authors/christian-lazaro.json'
-import { addOpenGraphProfileMetadataFromAuthor } from './add-open-graph-profile-metadata-from-author'
+import aboutPageContent from '../../data/misc/about.json'
 import { getMetadataFromJson } from '../common/routing/get-metadata-from-json'
+import { addOpenGraphProfileMetadata } from './add-open-graph-profile-metadata-from-author'
 
 @NgModule({
   declarations: [],
@@ -15,9 +15,9 @@ import { getMetadataFromJson } from '../common/routing/get-metadata-from-json'
         component: AboutPageComponent,
         data: {
           NgaoxSeo: {
-            ...addOpenGraphProfileMetadataFromAuthor(
+            ...addOpenGraphProfileMetadata(
               getMetadataFromJson(aboutPageMetadata),
-              christianLazaro,
+              aboutPageContent.openGraphProfile,
             ),
           },
         },

--- a/src/app/about-page/add-open-graph-profile-metadata-from-author.ts
+++ b/src/app/about-page/add-open-graph-profile-metadata-from-author.ts
@@ -1,34 +1,40 @@
 import { IPageSeoData } from '@ngaox/seo'
-import { Author } from '../common/authors.service'
 import { MetaDefinition } from '@angular/platform-browser'
 
-export function addOpenGraphProfileMetadataFromAuthor(
+interface OpenGraphProfileMetadata {
+  readonly firstName: string
+  readonly lastName: string
+  readonly gender?: string
+  readonly username?: string
+}
+
+export function addOpenGraphProfileMetadata(
   metadata: IPageSeoData,
-  author: Author,
+  openGraphProfileMetadata: OpenGraphProfileMetadata,
 ): IPageSeoData {
   const extras: MetaDefinition[] = []
-  if (author.firstName && author.firstName.length > 0) {
+  if (isNonEmptyString(openGraphProfileMetadata.firstName)) {
     extras.push({
       property: 'og:profile:first_name',
-      content: author.firstName,
+      content: openGraphProfileMetadata.firstName,
     })
   }
-  if (author.lastName && author.lastName.length > 0) {
+  if (isNonEmptyString(openGraphProfileMetadata.lastName)) {
     extras.push({
       property: 'og:profile:last_name',
-      content: author.lastName,
+      content: openGraphProfileMetadata.lastName,
     })
   }
-  if (author.gender && author.gender.length > 0) {
+  if (isNonEmptyString(openGraphProfileMetadata.gender)) {
     extras.push({
       property: 'og:profile:gender',
-      content: author.gender,
+      content: openGraphProfileMetadata.gender,
     })
   }
-  if (author.social?.mainUsername && author.social.mainUsername.length > 0) {
+  if (isNonEmptyString(openGraphProfileMetadata.username)) {
     extras.push({
       property: 'og:profile:username',
-      content: author.social.mainUsername,
+      content: openGraphProfileMetadata.username,
     })
   }
 
@@ -37,4 +43,8 @@ export function addOpenGraphProfileMetadataFromAuthor(
     type: 'profile',
     extra: [...(metadata.extra ?? []), ...extras],
   }
+}
+
+function isNonEmptyString(string: string | undefined): string is string {
+  return string !== undefined && string.trim().length > 0
 }

--- a/src/app/common/authors.service.ts
+++ b/src/app/common/authors.service.ts
@@ -31,13 +31,9 @@ export const AUTHORS_JSON = new InjectionToken<typeof authors>(
 )
 export type Author = {
   slug?: string
-  firstName: string
-  lastName: string
-  gender?: string
-  username?: string
+  name: string
   social?: {
-    mainName?: string | null
-    mainUsername?: string
+    preferred?: string | null
     instagram?: string
     linkedin?: string
     tiktok?: string

--- a/src/app/common/social/social.service.ts
+++ b/src/app/common/social/social.service.ts
@@ -25,10 +25,16 @@ export class SocialService {
 
   public getMain(author: Author): Social | undefined {
     const socials = this.mapAll(author.social)
-    if (author.social?.mainName && this.isSocialName(author.social.mainName)) {
-      const mainUsername = author.social[author.social.mainName]
-      if (!!mainUsername && mainUsername.length > 0)
-        return this.mapFromNameAndUsername(author.social.mainName, mainUsername)
+    if (
+      author.social?.preferred &&
+      this.isSocialName(author.social.preferred)
+    ) {
+      const mainUsername = author.social[author.social.preferred]
+      if (!!mainUsername && mainUsername.trim().length > 0)
+        return this.mapFromNameAndUsername(
+          author.social.preferred,
+          mainUsername,
+        )
     }
     const sortedSocials = Array.from(socials).sort(
       (a, b) =>

--- a/src/app/projects/projects-page/project-list-item/project-list-item.component.html
+++ b/src/app/projects/projects-page/project-list-item/project-list-item.component.html
@@ -28,10 +28,7 @@
 <div class="credits" *ngIf="credits && credits.length">
   <ng-container *ngFor="let credit of credits">
     <span *ngIf="credit.author">
-      {{ credit.role }}: {{ credit.author.firstName }}
-      <ng-container *ngIf="credit.author.lastName">
-        {{ credit.author.lastName }}
-      </ng-container>
+      {{ credit.role }}: {{ credit.author.name }}
       <span class="anchor" *ngIf="credit.social"
         >(<a [href]="credit.social.url.toString()" target="_blank"
           >@{{ credit.social.username }}</a

--- a/src/content/projects/chiasma.json
+++ b/src/content/projects/chiasma.json
@@ -33,19 +33,19 @@
       "authorSlug": "alejandro-flama"
     },
     {
-      "authorSlug": "map-firstname-daniela-lastname-velazquez-social-map-mainname-instagram-mainusername-instagram-danielaev-b",
+      "authorSlug": "daniela-velazquez",
       "role": "MUA"
     },
     {
       "role": "Model",
-      "authorSlug": "map-firstname-karlo-lastname-vargas-social-map-mainname-instagram-instagram-karlovargas"
+      "authorSlug": "karlo-vargas"
     },
     {
-      "authorSlug": "map-firstname-my-fucking-lastname-studio-social-map-mainname-instagram-instagram-myfuckingstudio-bcn",
+      "authorSlug": "my-fucking-studio",
       "role": "Studio"
     },
     {
-      "authorSlug": "map-social-map-mainname-instagram-instagram-belenguts-firstname-belen-lastname-navas",
+      "authorSlug": "belen-navas",
       "role": "Assistant Director"
     },
     {

--- a/src/data/authors/alejandro-flama.json
+++ b/src/data/authors/alejandro-flama.json
@@ -1,6 +1,5 @@
 {
-  "firstName": "Alejandro",
-  "lastName": "Flama",
+  "name": "Alejandro Flama",
   "social": {
     "instagram": "flama.ph"
   }

--- a/src/data/authors/belen-navas.json
+++ b/src/data/authors/belen-navas.json
@@ -1,0 +1,6 @@
+{
+  "name": "Belén Navas",
+  "social": {
+    "instagram": "belenguts"
+  }
+}

--- a/src/data/authors/christian-lazaro.json
+++ b/src/data/authors/christian-lazaro.json
@@ -1,9 +1,7 @@
 {
-  "firstName": "Christian",
-  "lastName": "Lázaro",
-  "gender": "male",
+  "name": "Christian Lázaro",
   "social": {
-    "mainUsername": "christian_labu",
+    "preferred": "instagram",
     "instagram": "christian_labu",
     "linkedin": "christianlazarobustamante",
     "tiktok": "christian_lazaro_"

--- a/src/data/authors/daniela-velazquez.json
+++ b/src/data/authors/daniela-velazquez.json
@@ -1,0 +1,6 @@
+{
+  "name": "Daniela Velázquez",
+  "social": {
+    "instagram": "danielaev.b"
+  }
+}

--- a/src/data/authors/karlo-vargas.json
+++ b/src/data/authors/karlo-vargas.json
@@ -1,0 +1,6 @@
+{
+  "name": "Karlo Vargas",
+  "social": {
+    "instagram": "karlovargas"
+  }
+}

--- a/src/data/authors/map-firstname-daniela-lastname-velazquez-social-map-mainname-instagram-mainusername-instagram-danielaev-b.json
+++ b/src/data/authors/map-firstname-daniela-lastname-velazquez-social-map-mainname-instagram-mainusername-instagram-danielaev-b.json
@@ -1,9 +1,0 @@
-{
-  "firstName": "Daniela ",
-  "lastName": "Velázquez",
-  "social": {
-    "mainName": "instagram",
-    "mainUsername": "",
-    "instagram": "danielaev.b"
-  }
-}

--- a/src/data/authors/map-firstname-karlo-lastname-vargas-social-map-mainname-instagram-instagram-karlovargas.json
+++ b/src/data/authors/map-firstname-karlo-lastname-vargas-social-map-mainname-instagram-instagram-karlovargas.json
@@ -1,8 +1,0 @@
-{
-  "firstName": "Karlo",
-  "lastName": "Vargas",
-  "social": {
-    "mainName": "instagram",
-    "instagram": "karlovargas"
-  }
-}

--- a/src/data/authors/map-firstname-my-fucking-lastname-studio-social-map-mainname-instagram-instagram-myfuckingstudio-bcn.json
+++ b/src/data/authors/map-firstname-my-fucking-lastname-studio-social-map-mainname-instagram-instagram-myfuckingstudio-bcn.json
@@ -1,8 +1,0 @@
-{
-  "firstName": "My fucking ",
-  "lastName": "studio",
-  "social": {
-    "mainName": "instagram",
-    "instagram": "myfuckingstudio.bcn"
-  }
-}

--- a/src/data/authors/map-social-map-mainname-instagram-instagram-belenguts-firstname-belen-lastname-navas.json
+++ b/src/data/authors/map-social-map-mainname-instagram-instagram-belenguts-firstname-belen-lastname-navas.json
@@ -1,8 +1,0 @@
-{
-  "social": {
-    "mainName": "instagram",
-    "instagram": "belenguts"
-  },
-  "firstName": "Belén",
-  "lastName": "Navas"
-}

--- a/src/data/authors/my-fucking-studio.json
+++ b/src/data/authors/my-fucking-studio.json
@@ -1,0 +1,6 @@
+{
+  "name": "My fucking studio",
+  "social": {
+    "instagram": "myfuckingstudio.bcn"
+  }
+}

--- a/src/data/misc/about.json
+++ b/src/data/misc/about.json
@@ -1,6 +1,12 @@
 {
   "title": "About me",
   "text": "I am Christian Lázaro, fashion designer living in Barcelona, Spain. I was raised in Spain, but I lived 6 years of my life in Peru, where I was born. My whole life I have lived between two different cultures, which have nurture and gave me a wider vision leading me to see things from different perspectives. \n\nThe creative world has always had a hold on me, I believe design and fashion can represent experiences, wishes and dreams uniquely. Through the last years, besides learning about fashion, I have developed special interest in editorial and fashion photography, styling, composition and storytelling to bring different concepts into fashion. Moreover, I have been part of the Spain team that develops colour tendencies at international level.",
+  "openGraphProfile": {
+    "firstName": "Christian",
+    "lastName": "Lázaro",
+    "gender": "male",
+    "username": "christian_labu"
+  },
   "resume": [
     {
       "displayName": "CV (spanish)",


### PR DESCRIPTION
Seems that after a refactoring of authors, the identifier field `name` was left outdated. So slug was the default one (a very weird one). This was because first name and last name was introduced in order to fill the about page open graph profile metadata. Buuut applying to all authors causes:
 - No identifier field (first name is not identificative enough, last name either). Social networks are optional. And can't combine first + last name
 - If author is a business, there's no "first / last" name

So moving the open graph profile metadata to about page data. And leaving "name" in authors.

Manually refactored all authors to match this new shape + renamed files with slugs from `name` field

Also renamed `mainName` to `preferred` inside the social fields