### PR TITLE
fix(projects): video iframe max 100% width

### DIFF
--- a/src/app/projects/project-page/project-page.component.scss
+++ b/src/app/projects/project-page/project-page.component.scss
@@ -26,9 +26,7 @@
       width: 100%;
       //ℹ️ max-width set by component for big screens
     }
-  }
 
-  .video {
     iframe {
       max-width: 100%;
     }


### PR DESCRIPTION
Video `iframe` was overflowing in small screens cause `video` class wasn't used
