### PR TITLE
refactor: add vw to responsive breakpoints service

### DIFF
--- a/src/app/about-page/about-page.component.html
+++ b/src/app/about-page/about-page.component.html
@@ -6,12 +6,12 @@
 <p class="link">{{ emailLocalPart }}@{{ domainName }}</p>
 <article>
   <img
-    [ngSrc]="portraitImage.filePath"
-    [ngSrcset]="srcSet"
-    [sizes]="sizes"
-    [height]="portraitImage.height"
-    [width]="portraitImage.width"
-    [alt]="portraitImage.alt"
+    [ngSrc]="portrait.asset.filePath"
+    [height]="portrait.asset.height"
+    [width]="portrait.asset.width"
+    [alt]="portrait.asset.alt"
+    [ngSrcset]="portrait.attributes.ngSrcSet.toString()"
+    [sizes]="portrait.attributes.sizes.toString()"
     priority="true"
   />
   <p>{{ text }}</p>

--- a/src/app/about-page/about-page.component.scss
+++ b/src/app/about-page/about-page.component.scss
@@ -24,6 +24,7 @@
     @include typographies.bold;
   }
 
+  /** 👇 Keep in sync with component responsive image breakpoints **/
   article {
     display: flex;
     flex-direction: column;

--- a/src/app/about-page/about-page.component.ts
+++ b/src/app/about-page/about-page.component.ts
@@ -1,9 +1,12 @@
 import { Component, Inject } from '@angular/core'
 import aboutPageContents from '../../data/misc/about.json'
-import { ImageResponsiveBreakpointsService } from '../common/images/image-responsive-breakpoints.service'
-import { ImageAsset } from '../common/images/image-asset'
 import { MISC_IMAGES, MiscImages } from '../common/images/misc-images'
 import defaultMetadata from '../../data/misc/metadata.json'
+import { ResponsiveImage } from '../common/images/responsive-image'
+import { ResponsiveImageAttributesService } from '../common/images/responsive-image-attributes.service'
+import { Vw } from '../common/css/unit/vw'
+import { CssMinMaxMediaQuery } from '../common/css/css-min-max-media-query'
+import { Breakpoint } from '../common/style/breakpoint'
 
 @Component({
   selector: 'app-about-page',
@@ -13,21 +16,29 @@ import defaultMetadata from '../../data/misc/metadata.json'
 export class AboutPageComponent {
   public readonly title: string = aboutPageContents.title
   public readonly text: string = aboutPageContents.text
-  public readonly srcSet: string = this.imageResponsiveBreakpointsService
-    .range(
-      this.imageResponsiveBreakpointsService.MIN_SCREEN_WIDTH_PX / 3,
-      this.imageResponsiveBreakpointsService.MAX_SCREEN_WIDTH_PX / 5,
-    )
-    .toSrcSet()
-  public readonly sizes: string = 'calc(33.33vw - 16px), calc(20vw - 16px)'
-  public readonly portraitImage: ImageAsset
+  public readonly portrait: ResponsiveImage
   public readonly emailLocalPart: string = 'contact'
   public readonly domainName = new URL(defaultMetadata.canonicalUrl).hostname
 
   constructor(
     @Inject(MISC_IMAGES) miscImages: MiscImages,
-    private imageResponsiveBreakpointsService: ImageResponsiveBreakpointsService,
+    responsiveImageAttributesService: ResponsiveImageAttributesService,
   ) {
-    this.portraitImage = miscImages.aboutPortrait
+    //👇 Keep in sync with SCSS
+    this.portrait = new ResponsiveImage(
+      miscImages.aboutPortrait,
+      responsiveImageAttributesService
+        .vw(Vw(35))
+        .with(
+          responsiveImageAttributesService.vw(
+            Vw(60),
+            CssMinMaxMediaQuery.minMax(Breakpoint.Xs.px, Breakpoint.S.almost),
+          ),
+          responsiveImageAttributesService.vw(
+            Vw(75),
+            CssMinMaxMediaQuery.max(Breakpoint.Xs.almost),
+          ),
+        ),
+    )
   }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core'
-import { ENTER_LEAVE_FADE_IN_OUT_ANIMATIONS } from './common/animations'
+import { ENTER_LEAVE_FADE_IN_OUT_ANIMATIONS } from './common/style/animations'
 
 @Component({
   selector: 'app-root',

--- a/src/app/common/css/css-max-width-media-feature.ts
+++ b/src/app/common/css/css-max-width-media-feature.ts
@@ -1,0 +1,16 @@
+import { CssUnit } from './unit/css-unit'
+import { CssMediaFeature } from './css-media-feature'
+
+export class CssMaxWidthMediaFeature<
+  U extends CssUnit,
+> extends CssMediaFeature<U> {
+  public readonly name = 'max-width'
+
+  constructor(public readonly value: U) {
+    super()
+  }
+
+  public static from<U extends CssUnit>(maxWidth: U) {
+    return new this(maxWidth)
+  }
+}

--- a/src/app/common/css/css-media-feature.ts
+++ b/src/app/common/css/css-media-feature.ts
@@ -1,0 +1,10 @@
+import { CssMediaQuery } from './css-media-query'
+
+export abstract class CssMediaFeature<T> implements CssMediaQuery {
+  public abstract readonly name: string
+  public abstract readonly value: T
+
+  public toString(): string {
+    return `(${this.name}: ${this.value})`
+  }
+}

--- a/src/app/common/css/css-media-query.ts
+++ b/src/app/common/css/css-media-query.ts
@@ -1,0 +1,3 @@
+export interface CssMediaQuery {
+  toString(): string
+}

--- a/src/app/common/css/css-min-max-media-query.ts
+++ b/src/app/common/css/css-min-max-media-query.ts
@@ -1,0 +1,61 @@
+import { CssMinWidthMediaFeature } from './css-min-width-media-feature'
+import { CssMaxWidthMediaFeature } from './css-max-width-media-feature'
+import { CssMediaQuery } from './css-media-query'
+import { CssUnit } from './unit/css-unit'
+
+export class CssMinMaxMediaQuery<
+  MinUnit extends CssUnit,
+  MaxUnit extends CssUnit,
+> implements CssMediaQuery
+{
+  public readonly min?: CssMinWidthMediaFeature<MinUnit>
+  public readonly max?: CssMaxWidthMediaFeature<MaxUnit>
+
+  private constructor({
+    min,
+    max,
+  }:
+    | {
+        min: CssMinWidthMediaFeature<MinUnit>
+        max?: CssMaxWidthMediaFeature<MaxUnit>
+      }
+    | {
+        min?: CssMinWidthMediaFeature<MinUnit>
+        max: CssMaxWidthMediaFeature<MaxUnit>
+      }
+    | {
+        min: CssMinWidthMediaFeature<MinUnit>
+        max: CssMaxWidthMediaFeature<MaxUnit>
+      }) {
+    this.min = min
+    this.max = max
+  }
+
+  public static min<U extends CssUnit>(minWidth: U) {
+    return new this<U, U>({ min: CssMinWidthMediaFeature.from(minWidth) })
+  }
+
+  public static max<U extends CssUnit>(maxWidth: U) {
+    return new this<U, U>({ max: CssMaxWidthMediaFeature.from(maxWidth) })
+  }
+
+  public static minMax<MinUnit extends CssUnit, MaxUnit extends CssUnit>(
+    minWidth: MinUnit,
+    maxWidth: MaxUnit,
+  ) {
+    return new this({
+      min: CssMinWidthMediaFeature.from(minWidth),
+      max: CssMaxWidthMediaFeature.from(maxWidth),
+    })
+  }
+
+  public toString(): string {
+    const mediaFeatures = [this.min, this.max].filter(
+      (mediaFeature) => !!mediaFeature,
+    )
+    if (mediaFeatures.length === 1) {
+      return mediaFeatures.join('')
+    }
+    return `(${mediaFeatures.join(' and ')})`
+  }
+}

--- a/src/app/common/css/css-min-width-media-feature.ts
+++ b/src/app/common/css/css-min-width-media-feature.ts
@@ -1,0 +1,16 @@
+import { CssMediaFeature } from './css-media-feature'
+import { CssUnit } from './unit/css-unit'
+
+export class CssMinWidthMediaFeature<
+  U extends CssUnit,
+> extends CssMediaFeature<U> {
+  public readonly name = 'min-width'
+
+  private constructor(public readonly value: U) {
+    super()
+  }
+
+  public static from<U extends CssUnit>(minWidth: U) {
+    return new this(minWidth)
+  }
+}

--- a/src/app/common/css/unit/css-unit.ts
+++ b/src/app/common/css/unit/css-unit.ts
@@ -1,0 +1,8 @@
+export abstract class CssUnit {
+  public abstract readonly value: number
+  public abstract readonly unit: string
+
+  toString(): string {
+    return `${this.value}${this.unit}`
+  }
+}

--- a/src/app/common/css/unit/px.ts
+++ b/src/app/common/css/unit/px.ts
@@ -1,0 +1,12 @@
+import { CssUnit } from './css-unit'
+
+export class CssPxUnit extends CssUnit {
+  public readonly unit = 'px'
+
+  constructor(public readonly value: number) {
+    super()
+  }
+}
+
+export const Px = (...args: ConstructorParameters<typeof CssPxUnit>) =>
+  new CssPxUnit(...args)

--- a/src/app/common/css/unit/vw.ts
+++ b/src/app/common/css/unit/vw.ts
@@ -1,0 +1,15 @@
+import { CssUnit } from './css-unit'
+
+export class CssVwUnit extends CssUnit {
+  readonly unit = 'vw'
+
+  constructor(public readonly value: number) {
+    if (value <= 0 || value > 100) {
+      throw new Error(`Invalid vw value ${value}`)
+    }
+    super()
+  }
+}
+
+export const Vw = (...args: ConstructorParameters<typeof CssVwUnit>) =>
+  new CssVwUnit(...args)

--- a/src/app/common/html/html-image-sizes-attribute.ts
+++ b/src/app/common/html/html-image-sizes-attribute.ts
@@ -1,0 +1,18 @@
+import { HtmlImageSizesSingleAttribute } from './html-image-sizes-single-attribute'
+
+export class HtmlImageSizesAttribute {
+  constructor(
+    public readonly sizes: ReadonlyArray<HtmlImageSizesSingleAttribute>,
+  ) {}
+
+  public with(...others: ReadonlyArray<HtmlImageSizesAttribute>) {
+    return new HtmlImageSizesAttribute([
+      ...this.sizes,
+      ...others.map(({ sizes }) => sizes).flat(),
+    ])
+  }
+
+  public toString(): string {
+    return this.sizes.join(', ')
+  }
+}

--- a/src/app/common/html/html-image-sizes-single-attribute.ts
+++ b/src/app/common/html/html-image-sizes-single-attribute.ts
@@ -1,0 +1,15 @@
+import { CssMediaQuery } from '../css/css-media-query'
+import { CssUnit } from '../css/unit/css-unit'
+import { isDefined } from '../is-defined'
+
+export class HtmlImageSizesSingleAttribute {
+  constructor(
+    public readonly width: CssUnit,
+    public readonly mediaQuery?: CssMediaQuery,
+  ) {}
+
+  public toString(): string {
+    const parts = [this.mediaQuery, this.width].filter(isDefined)
+    return parts.map((part) => part.toString()).join(' ')
+  }
+}

--- a/src/app/common/html/html-ng-src-set-attribute.ts
+++ b/src/app/common/html/html-ng-src-set-attribute.ts
@@ -1,0 +1,17 @@
+import { ResponsiveImageBreakpoints } from '../images/responsive-image-breakpoints'
+
+export class HtmlNgSrcSetAttribute {
+  constructor(public readonly breakpoints: ResponsiveImageBreakpoints) {}
+
+  public toString(): string {
+    return this.breakpoints.list
+      .map((breakpoint) => `${breakpoint.value}w`)
+      .join(', ')
+  }
+
+  public with(...others: ReadonlyArray<HtmlNgSrcSetAttribute>) {
+    return new HtmlNgSrcSetAttribute(
+      this.breakpoints.with(...others.map(({ breakpoints }) => breakpoints)),
+    )
+  }
+}

--- a/src/app/common/images/responsive-image-attributes.service.ts
+++ b/src/app/common/images/responsive-image-attributes.service.ts
@@ -1,34 +1,76 @@
 import { Injectable } from '@angular/core'
 import { ResponsiveImageAttributes } from './responsive-image-attributes'
-import { getBreakpoints } from '@unpic/core'
+import { DEFAULT_RESOLUTIONS, getBreakpoints } from '@unpic/core'
+import { CssVwUnit, Vw } from '../css/unit/vw'
+import { CssMinMaxMediaQuery } from '../css/css-min-max-media-query'
+import { HtmlImageSizesSingleAttribute } from '../html/html-image-sizes-single-attribute'
+import { CssPxUnit, Px } from '../css/unit/px'
+import { HtmlNgSrcSetAttribute } from '../html/html-ng-src-set-attribute'
+import { HtmlImageSizesAttribute } from '../html/html-image-sizes-attribute'
+import { ResponsiveImageBreakpoints } from './responsive-image-breakpoints'
 
 @Injectable({
   providedIn: 'root',
 })
 export class ResponsiveImageAttributesService {
+  private MAX_RESOLUTION_WIDTH = Math.max(...DEFAULT_RESOLUTIONS)
+
   /**
    * Returns responsive image attributes for an image constrained in size
    *
    * Inspired from unpic lib. Can't use that lib because they don't support ImageKit
    * It's noted to contribute when have some time!
    *
-   * Supports images that don't take full screen when on small screens (unlike unpic)
-   *
    * @see https://github.com/ascorbic/unpic-img/blob/core-v0.0.35/packages/core/src/core.ts#L315-L348
    */
-  public constrained({
-    minWidthVw = 100,
-    maxWidthPx,
-  }: {
-    minWidthVw?: number
-    maxWidthPx: number
-  }): ResponsiveImageAttributes {
-    const maxWidthPxInt = Math.ceil(maxWidthPx)
+  public constrained(constrainedWidth: CssPxUnit): ResponsiveImageAttributes {
     const breakpoints = getBreakpoints({
-      width: maxWidthPxInt,
+      width: constrainedWidth.value,
       layout: 'constrained',
-    })
-    const sizes = `(min-width: ${maxWidthPxInt}px) ${maxWidthPxInt}px, ${minWidthVw}vw`
-    return ResponsiveImageAttributes.fromBreakpointsAndSizes(breakpoints, sizes)
+    }).map((breakpoint) => Px(breakpoint))
+    return new ResponsiveImageAttributes(
+      new HtmlNgSrcSetAttribute(ResponsiveImageBreakpoints.from(breakpoints)),
+      new HtmlImageSizesAttribute([
+        new HtmlImageSizesSingleAttribute(
+          constrainedWidth,
+          CssMinMaxMediaQuery.min(constrainedWidth),
+        ),
+        new HtmlImageSizesSingleAttribute(Vw(100)),
+      ]),
+    )
+  }
+
+  public vw(
+    vw: CssVwUnit,
+    minMaxMediaQuery?: CssMinMaxMediaQuery<CssPxUnit, CssPxUnit>,
+  ) {
+    const breakpointsAtFixedVw = DEFAULT_RESOLUTIONS.filter(
+      (resolutionWidth) =>
+        (minMaxMediaQuery?.min?.value.value ?? -Infinity) <= resolutionWidth &&
+        resolutionWidth <= (minMaxMediaQuery?.max?.value.value ?? Infinity),
+    )
+      .map((resolutionWidth) => {
+        const breakpointAtResolution = Px(
+          Math.ceil((resolutionWidth * vw.value) / 100),
+        )
+        const breakpointsAtResolution = [breakpointAtResolution]
+        const doubleBreakpointAtResolution = Px(
+          breakpointAtResolution.value * 2,
+        )
+        // Add double for high density screens if not bigger than max resolution width
+        if (doubleBreakpointAtResolution.value <= this.MAX_RESOLUTION_WIDTH) {
+          breakpointsAtResolution.push(doubleBreakpointAtResolution)
+        }
+        return breakpointsAtResolution
+      })
+      .flat()
+    return new ResponsiveImageAttributes(
+      new HtmlNgSrcSetAttribute(
+        ResponsiveImageBreakpoints.from(breakpointsAtFixedVw),
+      ),
+      new HtmlImageSizesAttribute([
+        new HtmlImageSizesSingleAttribute(vw, minMaxMediaQuery),
+      ]),
+    )
   }
 }

--- a/src/app/common/images/responsive-image-attributes.ts
+++ b/src/app/common/images/responsive-image-attributes.ts
@@ -1,16 +1,18 @@
+import { HtmlImageSizesAttribute } from '../html/html-image-sizes-attribute'
+import { HtmlNgSrcSetAttribute } from '../html/html-ng-src-set-attribute'
+
 export class ResponsiveImageAttributes {
   constructor(
-    public readonly ngSrcSet: string,
-    public readonly sizes: string,
+    public readonly ngSrcSet: HtmlNgSrcSetAttribute,
+    public readonly sizes: HtmlImageSizesAttribute,
   ) {}
 
-  static fromBreakpointsAndSizes(
-    pxBreakpoints: ReadonlyArray<number>,
-    sizes: string,
-  ) {
-    return new this(
-      pxBreakpoints.map((pxBreakpoint) => `${pxBreakpoint}w`).join(', '),
-      sizes,
+  public with(
+    ...others: ReadonlyArray<ResponsiveImageAttributes>
+  ): ResponsiveImageAttributes {
+    return new ResponsiveImageAttributes(
+      this.ngSrcSet.with(...others.map(({ ngSrcSet }) => ngSrcSet)),
+      this.sizes.with(...others.map(({ sizes }) => sizes)),
     )
   }
 }

--- a/src/app/common/images/responsive-image-breakpoints-reducer.ts
+++ b/src/app/common/images/responsive-image-breakpoints-reducer.ts
@@ -1,0 +1,46 @@
+// Amount of bytes Lighthouse considers is good enough to avoid generating a new breakpoint
+// https://github.com/GoogleChrome/lighthouse/blob/v11.3.0/core/audits/byte-efficiency/uses-responsive-images.js#L34-L37C55
+const LIGHTHOUSE_BYTES_THRESHOLD = 12288
+// Amount of bytes each pixel takes (not considering compression)
+// at a true color bit depth
+const PX_SIZE_BYTES = 3
+const LIGHTHOUSE_PX_THRESHOLD = LIGHTHOUSE_BYTES_THRESHOLD / PX_SIZE_BYTES
+// Assuming portrait (where each width increase means moar pixels than if squared or landscape)
+const PORTRAIT_ASPECT_RATIO = 16 / 9
+const MINIMUM_PX_DISTANCE_BETWEEN_BREAKPOINTS = Math.floor(
+  Math.sqrt(LIGHTHOUSE_PX_THRESHOLD) * PORTRAIT_ASPECT_RATIO,
+)
+
+/**
+ * Reduces the amount of responsive image breakpoints for a `srcSet` in a list
+ * by grouping those that are very close together, and choosing the maximum
+ * breakpoint of the group
+ *
+ * Breakpoints are grouped by the approximate width that Lighthouse is happy to
+ * avoid generating a new size for it. Approx 100px width (see constants above)
+ */
+export function responsiveImageBreakpointsReducer(
+  breakpoints: ReadonlyArray<number>,
+): number[] {
+  const sortedBreakpoints = Array.from(breakpoints).sort((a, b) => a - b)
+  const breakpointGroups: number[][] = []
+  for (let i = 0; i < sortedBreakpoints.length; i++) {
+    const breakpointGroup = []
+    let j = 0
+    for (j = 0; i + j < sortedBreakpoints.length; j++) {
+      const breakpoint = sortedBreakpoints[i + j]
+      if (breakpointGroup.length === 0) {
+        breakpointGroup.push(sortedBreakpoints[i + j])
+        continue
+      }
+      const diff = breakpoint - breakpointGroup[0]
+      if (diff > MINIMUM_PX_DISTANCE_BETWEEN_BREAKPOINTS) {
+        break
+      }
+      breakpointGroup.push(breakpoint)
+    }
+    breakpointGroups.push(breakpointGroup)
+    i += j - 1
+  }
+  return breakpointGroups.map((breakpointGroup) => Math.max(...breakpointGroup))
+}

--- a/src/app/common/images/responsive-image-breakpoints.ts
+++ b/src/app/common/images/responsive-image-breakpoints.ts
@@ -1,0 +1,22 @@
+import { CssPxUnit, Px } from '../css/unit/px'
+import { responsiveImageBreakpointsReducer } from './responsive-image-breakpoints-reducer'
+
+export class ResponsiveImageBreakpoints {
+  private constructor(public readonly list: ReadonlyArray<CssPxUnit>) {}
+
+  static from(list: ReadonlyArray<CssPxUnit>): ResponsiveImageBreakpoints {
+    return new this(
+      responsiveImageBreakpointsReducer(
+        list.map((breakpoint) => breakpoint.value),
+      ).map((breakpoint) => Px(breakpoint)),
+    )
+  }
+
+  public with(
+    ...others: ReadonlyArray<ResponsiveImageBreakpoints>
+  ): ResponsiveImageBreakpoints {
+    return ResponsiveImageBreakpoints.from(
+      [...this.list, ...others.map(({ list }) => list)].flat(),
+    )
+  }
+}

--- a/src/app/common/is-defined.ts
+++ b/src/app/common/is-defined.ts
@@ -1,0 +1,3 @@
+export function isDefined<T>(val: T | undefined | null): val is T {
+  return val !== undefined && val !== null
+}

--- a/src/app/common/style/animations.ts
+++ b/src/app/common/style/animations.ts
@@ -8,7 +8,7 @@ import {
   trigger,
 } from '@angular/animations' // https://m3.material.io/styles/motion
 
-// To keep in sync with SCSS
+// 👇 Keep in sync with SCSS
 // https://m3.material.io/styles/motion
 export const STANDARD_DURATION = '.3s'
 export const EMPHASIZED_DURATION = '.5s'

--- a/src/app/common/style/breakpoint.ts
+++ b/src/app/common/style/breakpoint.ts
@@ -1,0 +1,13 @@
+import { CssPxUnit, Px } from '../css/unit/px'
+
+export class Breakpoint {
+  private constructor(public readonly px: CssPxUnit) {}
+
+  public get almost(): CssPxUnit {
+    return Px(this.px.value - 0.02)
+  }
+
+  //👇 Keep in sync with breakpoints Scss
+  static readonly Xs = new this(Px(600))
+  static readonly S = new this(Px(960))
+}

--- a/src/app/logo/logo.component.html
+++ b/src/app/logo/logo.component.html
@@ -5,7 +5,7 @@
     [width]="horizontalLogo.asset.width"
     [height]="horizontalLogo.asset.height"
     [priority]="true"
-    [ngSrcset]="horizontalLogo.attributes.ngSrcSet"
-    [sizes]="horizontalLogo.attributes.sizes"
+    [ngSrcset]="horizontalLogo.attributes.ngSrcSet.toString()"
+    [sizes]="horizontalLogo.attributes.sizes.toString()"
   />
 </a>

--- a/src/app/logo/logo.component.ts
+++ b/src/app/logo/logo.component.ts
@@ -2,6 +2,7 @@ import { Component, Inject } from '@angular/core'
 import { MISC_IMAGES, MiscImages } from '../common/images/misc-images'
 import { ResponsiveImage } from '../common/images/responsive-image'
 import { ResponsiveImageAttributesService } from '../common/images/responsive-image-attributes.service'
+import { Px } from '../common/css/unit/px'
 
 @Component({
   selector: 'app-logo',
@@ -22,7 +23,7 @@ export class LogoComponent {
     const maxWidthPx = aspectRatio * this.LOGO_MAX_HEIGHT_PX
     this.horizontalLogo = new ResponsiveImage(
       miscImages.horizontalLogo,
-      responsiveImageAttributesService.constrained({ maxWidthPx }),
+      responsiveImageAttributesService.constrained(Px(Math.ceil(maxWidthPx))),
     )
   }
 }

--- a/src/sass/_animations.scss
+++ b/src/sass/_animations.scss
@@ -1,4 +1,4 @@
-// To keep in sync with TypeScript code
+// 👇 Keep in sync with TypeScript code
 $timing-function: cubic-bezier(0.2, 0, 0, 1);
 $standard-duration: 0.3s;
 @mixin standard {

--- a/src/sass/_breakpoints.scss
+++ b/src/sass/_breakpoints.scss
@@ -3,6 +3,8 @@
  *
  * Obtained from Angular CDK
  * https://github.com/angular/components/blob/16.2.1/src/cdk/layout/breakpoints.ts
+ *
+ * 👇 Keep in sync with Typescript component code
  */
 @function almost($pixels) {
   @return $pixels - 0.02px;


### PR DESCRIPTION
Adds method to generate responsive image attributes when those are specified in `vw` units and may change depending on min/max media queries

Tests it by using it in the about page

Others:
 - Move animations to `style` directory inside `common`
