### PR TITLE
feat(projects): use responsive images service in list item

### DIFF
--- a/src/app/about-page/about-page.component.html
+++ b/src/app/about-page/about-page.component.html
@@ -10,8 +10,8 @@
     [height]="portrait.asset.height"
     [width]="portrait.asset.width"
     [alt]="portrait.asset.alt"
-    [ngSrcset]="portrait.attributes.ngSrcSet.toString()"
-    [sizes]="portrait.attributes.sizes.toString()"
+    [ngSrcset]="portrait.attributes.ngSrcSet.asString"
+    [sizes]="portrait.attributes.sizes.asString"
     priority="true"
   />
   <p>{{ text }}</p>

--- a/src/app/common/html/html-image-sizes-attribute.ts
+++ b/src/app/common/html/html-image-sizes-attribute.ts
@@ -1,18 +1,18 @@
 import { HtmlImageSizesSingleAttribute } from './html-image-sizes-single-attribute'
 
 export class HtmlImageSizesAttribute {
+  public readonly asString: string
+
   constructor(
     public readonly sizes: ReadonlyArray<HtmlImageSizesSingleAttribute>,
-  ) {}
+  ) {
+    this.asString = this.sizes.join(', ')
+  }
 
   public with(...others: ReadonlyArray<HtmlImageSizesAttribute>) {
     return new HtmlImageSizesAttribute([
       ...this.sizes,
       ...others.map(({ sizes }) => sizes).flat(),
     ])
-  }
-
-  public toString(): string {
-    return this.sizes.join(', ')
   }
 }

--- a/src/app/common/html/html-ng-src-set-attribute.ts
+++ b/src/app/common/html/html-ng-src-set-attribute.ts
@@ -1,10 +1,10 @@
 import { ResponsiveImageBreakpoints } from '../images/responsive-image-breakpoints'
 
 export class HtmlNgSrcSetAttribute {
-  constructor(public readonly breakpoints: ResponsiveImageBreakpoints) {}
+  public readonly asString: string
 
-  public toString(): string {
-    return this.breakpoints.list
+  constructor(public readonly breakpoints: ResponsiveImageBreakpoints) {
+    this.asString = this.breakpoints.list
       .map((breakpoint) => `${breakpoint.value}w`)
       .join(', ')
   }

--- a/src/app/common/images/responsive-image-attributes.service.ts
+++ b/src/app/common/images/responsive-image-attributes.service.ts
@@ -14,6 +14,12 @@ import { ResponsiveImageBreakpoints } from './responsive-image-breakpoints'
 })
 export class ResponsiveImageAttributesService {
   private MAX_RESOLUTION_WIDTH = Math.max(...DEFAULT_RESOLUTIONS)
+  private RESOLUTIONS = [
+    ...DEFAULT_RESOLUTIONS,
+    //👇 For Lighthouse, which tests it on a Moto G Power (412x823)
+    // Pretty old tbh 🤷
+    320,
+  ]
 
   /**
    * Returns responsive image attributes for an image constrained in size
@@ -44,7 +50,7 @@ export class ResponsiveImageAttributesService {
     vw: CssVwUnit,
     minMaxMediaQuery?: CssMinMaxMediaQuery<CssPxUnit, CssPxUnit>,
   ) {
-    const breakpointsAtFixedVw = DEFAULT_RESOLUTIONS.filter(
+    const breakpointsAtFixedVw = this.RESOLUTIONS.filter(
       (resolutionWidth) =>
         (minMaxMediaQuery?.min?.value.value ?? -Infinity) <= resolutionWidth &&
         resolutionWidth <= (minMaxMediaQuery?.max?.value.value ?? Infinity),

--- a/src/app/common/social/social.service.ts
+++ b/src/app/common/social/social.service.ts
@@ -75,7 +75,7 @@ export class SocialService {
           username,
           displayName: 'Instagram',
           icon: faInstagram,
-          url: new URL(`https://instagram.com/_u/${username}`),
+          url: new URL(`https://instagram.com/_u/${username}`).toString(),
         }
       case SocialName.LinkedIn:
         return {
@@ -83,7 +83,7 @@ export class SocialService {
           username,
           displayName: 'LinkedIn',
           icon: faLinkedinIn,
-          url: new URL(`https://linkedin.com/in/${username}`),
+          url: new URL(`https://linkedin.com/in/${username}`).toString(),
         }
       case SocialName.TikTok:
         return {
@@ -91,7 +91,7 @@ export class SocialService {
           username,
           displayName: 'TikTok',
           icon: faTiktok,
-          url: new URL(`https://tiktok.com/@${username}`),
+          url: new URL(`https://tiktok.com/@${username}`).toString(),
         }
     }
   }

--- a/src/app/common/social/social.ts
+++ b/src/app/common/social/social.ts
@@ -3,7 +3,7 @@ import { IconDefinition } from '@fortawesome/free-brands-svg-icons'
 export interface Social {
   readonly name: SocialName
   readonly username: string
-  readonly url: URL
+  readonly url: string
   readonly icon: IconDefinition
   readonly displayName: string
 }

--- a/src/app/logo/logo.component.html
+++ b/src/app/logo/logo.component.html
@@ -5,7 +5,7 @@
     [width]="horizontalLogo.asset.width"
     [height]="horizontalLogo.asset.height"
     [priority]="true"
-    [ngSrcset]="horizontalLogo.attributes.ngSrcSet.toString()"
-    [sizes]="horizontalLogo.attributes.sizes.toString()"
+    [ngSrcset]="horizontalLogo.attributes.ngSrcSet.asString"
+    [sizes]="horizontalLogo.attributes.sizes.asString"
   />
 </a>

--- a/src/app/projects/projects-page/project-list-item/project-list-item.component.html
+++ b/src/app/projects/projects-page/project-list-item/project-list-item.component.html
@@ -19,8 +19,8 @@
   <app-images-swiper
     *ngIf="_item.previewImages && _item.previewImages.length"
     [images]="_item.previewImages"
-    sizes="calc(50vw - 16px), 33.33vw"
-    [srcSet]="srcSet"
+    [sizes]="responsiveImageAttributes.sizes.asString"
+    [srcSet]="responsiveImageAttributes.ngSrcSet.asString"
     [priority]="priority"
     [customSwiperOptions]="CUSTOM_SWIPER_OPTIONS"
   ></app-images-swiper>
@@ -30,7 +30,7 @@
     <span *ngIf="credit.author">
       {{ credit.role }}: {{ credit.author.name }}
       <span class="anchor" *ngIf="credit.social"
-        >(<a [href]="credit.social.url.toString()" target="_blank"
+        >(<a [href]="credit.social.url" target="_blank"
           >@{{ credit.social.username }}</a
         >)</span
       >

--- a/src/app/projects/projects-page/project-list-item/project-list-item.component.scss
+++ b/src/app/projects/projects-page/project-list-item/project-list-item.component.scss
@@ -23,6 +23,7 @@
     flex-direction: column;
   }
 
+  //👇 Keep in sync with component responsive images
   app-images-swiper {
     // 👇 Seems swiper needs size set to work fine
     width: calc(100% - $texts-width-big-screen);

--- a/src/app/projects/projects-page/project-list-item/project-list-item.component.ts
+++ b/src/app/projects/projects-page/project-list-item/project-list-item.component.ts
@@ -1,12 +1,16 @@
 import { Component, Input } from '@angular/core'
 import { ProjectListItem } from '../../project-list-item'
 import { SwiperOptions } from 'swiper/types'
-import { ImageResponsiveBreakpointsService } from '../../../common/images/image-responsive-breakpoints.service'
 import { Author, AuthorsService } from '../../../common/authors.service'
 import { Social } from '../../../common/social/social'
 import { SocialService } from '../../../common/social/social.service'
 import { Credit } from '../../credit'
 import { PROJECTS_PATH } from '../../../common/routing/paths'
+import { ResponsiveImageAttributes } from '../../../common/images/responsive-image-attributes'
+import { ResponsiveImageAttributesService } from '../../../common/images/responsive-image-attributes.service'
+import { Vw } from '../../../common/css/unit/vw'
+import { CssMinMaxMediaQuery } from '../../../common/css/css-min-max-media-query'
+import { Breakpoint } from '../../../common/style/breakpoint'
 
 @Component({
   selector: 'app-project-list-item',
@@ -14,7 +18,31 @@ import { PROJECTS_PATH } from '../../../common/routing/paths'
   styleUrls: ['./project-list-item.component.scss'],
 })
 export class ProjectListItemComponent {
+  @Input() public priority?: boolean
+  public readonly CUSTOM_SWIPER_OPTIONS: SwiperOptions = {
+    slidesPerView: 2,
+  }
+  public readonly responsiveImageAttributes: ResponsiveImageAttributes
+  public credits?: ReadonlyArray<CreditItem>
+  protected readonly PROJECTS_PATH = PROJECTS_PATH
+
+  constructor(
+    private authorsService: AuthorsService,
+    private socialService: SocialService,
+    responsiveImageAttributesService: ResponsiveImageAttributesService,
+  ) {
+    this.responsiveImageAttributes = responsiveImageAttributesService
+      .vw(Vw(33.33))
+      .with(
+        responsiveImageAttributesService.vw(
+          Vw(50),
+          CssMinMaxMediaQuery.max(Breakpoint.S.px),
+        ),
+      )
+  }
+
   protected _item!: ProjectListItem
+
   @Input({ required: true })
   public set item(item: ProjectListItem) {
     this._item = item
@@ -28,26 +56,6 @@ export class ProjectListItemComponent {
       }
     })
   }
-
-  @Input() public priority?: boolean
-  public readonly CUSTOM_SWIPER_OPTIONS: SwiperOptions = {
-    slidesPerView: 2,
-  }
-  public srcSet = this.imageResponsiveBreakpointsService
-    .range(
-      this.imageResponsiveBreakpointsService.MIN_SCREEN_WIDTH_PX / 2,
-      this.imageResponsiveBreakpointsService.MAX_SCREEN_WIDTH_PX / 3,
-    )
-    .toSrcSet()
-  public credits?: ReadonlyArray<CreditItem>
-
-  constructor(
-    private imageResponsiveBreakpointsService: ImageResponsiveBreakpointsService,
-    private authorsService: AuthorsService,
-    private socialService: SocialService,
-  ) {}
-
-  protected readonly PROJECTS_PATH = PROJECTS_PATH
 }
 
 type CreditItem = Omit<Credit, 'authorSlug'> & {


### PR DESCRIPTION
Uses new responsive images service in project list item swiper

Also, refactors the responsive images attributes to build the string when creating the object. This way we avoid regenerating the string every time. Also, we avoid calling `toString` in the template, which is a bad practice as that computation could be expensive. And indeed, was computing the string every time.

Then Lighthouse failed:
 - https://github.com/davidlj95/chrislb/actions/runs/6787384401/job/18450148560
 - https://storage.googleapis.com/lighthouse-infrastructure.appspot.com/reports/1699374600612-61692.report.html

A bit weird 🤔 given the device Moto G Power used by Lighthouse has a screen resolution of 1080p. So images for almost that size should be fine given it's a resolution we generate images for (the 500vw one -> 1080/2). 

Added a 320 resolution cause that solved in the past. Emulated width is 412x823. Maybe that's the thing? (doesn't take into account density??) not sure tbh