### PR TITLE
refactor(projects): use new responsive images service for detail view

### DIFF
--- a/src/app/about-page/about-page.component.html
+++ b/src/app/about-page/about-page.component.html
@@ -10,7 +10,7 @@
     [height]="portrait.asset.height"
     [width]="portrait.asset.width"
     [alt]="portrait.asset.alt"
-    [ngSrcset]="portrait.attributes.ngSrcSet.asString"
+    [ngSrcset]="portrait.attributes.breakpoints.ngSrcSet.asString"
     [sizes]="portrait.attributes.sizes.asString"
     priority="true"
   />

--- a/src/app/about-page/about-page.component.ts
+++ b/src/app/about-page/about-page.component.ts
@@ -28,15 +28,17 @@ export class AboutPageComponent {
     this.portrait = new ResponsiveImage(
       miscImages.aboutPortrait,
       responsiveImageAttributesService
-        .vw(Vw(35))
+        .vw(Vw(35), CssMinMaxMediaQuery.min(Breakpoint.S.px))
         .with(
           responsiveImageAttributesService.vw(
             Vw(60),
             CssMinMaxMediaQuery.minMax(Breakpoint.Xs.px, Breakpoint.S.almost),
+            { includeMediaQueryInSizes: true },
           ),
           responsiveImageAttributesService.vw(
             Vw(75),
             CssMinMaxMediaQuery.max(Breakpoint.Xs.almost),
+            { includeMediaQueryInSizes: true },
           ),
         ),
     )

--- a/src/app/common/html/html-ng-src-set-attribute.ts
+++ b/src/app/common/html/html-ng-src-set-attribute.ts
@@ -4,8 +4,8 @@ export class HtmlNgSrcSetAttribute {
   public readonly asString: string
 
   constructor(public readonly breakpoints: ResponsiveImageBreakpoints) {
-    this.asString = this.breakpoints.list
-      .map((breakpoint) => `${breakpoint.value}w`)
+    this.asString = this.breakpoints.pxList
+      .map((breakpoint) => `${breakpoint}w`)
       .join(', ')
   }
 

--- a/src/app/common/images/responsive-image-attributes.ts
+++ b/src/app/common/images/responsive-image-attributes.ts
@@ -1,17 +1,21 @@
 import { HtmlImageSizesAttribute } from '../html/html-image-sizes-attribute'
-import { HtmlNgSrcSetAttribute } from '../html/html-ng-src-set-attribute'
+import { ResponsiveImageBreakpoints } from './responsive-image-breakpoints'
 
 export class ResponsiveImageAttributes {
   constructor(
-    public readonly ngSrcSet: HtmlNgSrcSetAttribute,
+    public readonly breakpoints: ResponsiveImageBreakpoints,
     public readonly sizes: HtmlImageSizesAttribute,
   ) {}
+
+  public reduce(): ResponsiveImageAttributes {
+    return new ResponsiveImageAttributes(this.breakpoints.reduce(), this.sizes)
+  }
 
   public with(
     ...others: ReadonlyArray<ResponsiveImageAttributes>
   ): ResponsiveImageAttributes {
     return new ResponsiveImageAttributes(
-      this.ngSrcSet.with(...others.map(({ ngSrcSet }) => ngSrcSet)),
+      this.breakpoints.with(...others.map(({ breakpoints }) => breakpoints)),
       this.sizes.with(...others.map(({ sizes }) => sizes)),
     )
   }

--- a/src/app/common/images/responsive-image-breakpoints-reducer.ts
+++ b/src/app/common/images/responsive-image-breakpoints-reducer.ts
@@ -1,46 +1,52 @@
-// Amount of bytes Lighthouse considers is good enough to avoid generating a new breakpoint
-// https://github.com/GoogleChrome/lighthouse/blob/v11.3.0/core/audits/byte-efficiency/uses-responsive-images.js#L34-L37C55
-const LIGHTHOUSE_BYTES_THRESHOLD = 12288
-// Amount of bytes each pixel takes (not considering compression)
-// at a true color bit depth
-const PX_SIZE_BYTES = 3
-const LIGHTHOUSE_PX_THRESHOLD = LIGHTHOUSE_BYTES_THRESHOLD / PX_SIZE_BYTES
-// Assuming portrait (where each width increase means moar pixels than if squared or landscape)
-const PORTRAIT_ASPECT_RATIO = 16 / 9
-const MINIMUM_PX_DISTANCE_BETWEEN_BREAKPOINTS = Math.floor(
-  Math.sqrt(LIGHTHOUSE_PX_THRESHOLD) * PORTRAIT_ASPECT_RATIO,
-)
+import { isSorted } from '../is-sorted'
 
 /**
  * Reduces the amount of responsive image breakpoints for a `srcSet` in a list
  * by grouping those that are very close together, and choosing the maximum
  * breakpoint of the group
  *
- * Breakpoints are grouped by the approximate width that Lighthouse is happy to
- * avoid generating a new size for it. Approx 100px width (see constants above)
+
  */
-export function responsiveImageBreakpointsReducer(
-  breakpoints: ReadonlyArray<number>,
-): number[] {
-  const sortedBreakpoints = Array.from(breakpoints).sort((a, b) => a - b)
-  const breakpointGroups: number[][] = []
-  for (let i = 0; i < sortedBreakpoints.length; i++) {
-    const breakpointGroup = []
-    let j = 0
-    for (j = 0; i + j < sortedBreakpoints.length; j++) {
-      const breakpoint = sortedBreakpoints[i + j]
-      if (breakpointGroup.length === 0) {
-        breakpointGroup.push(sortedBreakpoints[i + j])
-        continue
-      }
-      const diff = breakpoint - breakpointGroup[0]
-      if (diff > MINIMUM_PX_DISTANCE_BETWEEN_BREAKPOINTS) {
-        break
-      }
-      breakpointGroup.push(breakpoint)
-    }
-    breakpointGroups.push(breakpointGroup)
-    i += j - 1
+export class ResponsiveImageBreakpointsReducer {
+  constructor(public readonly maxPxBetweenBreakpoints: number) {}
+
+  /**
+   * Creates a new reducer with the maximum allows distance between breakpoints
+   * being the one that prevents Lighthouse from complaining
+   */
+  static default() {
+    // Amount of bytes Lighthouse considers is good enough to avoid generating
+    // a new image for that size
+    // https://github.com/GoogleChrome/lighthouse/blob/v11.3.0/core/audits/byte-efficiency/uses-responsive-images.js#L34-L37C55
+    const LIGHTHOUSE_BYTES_THRESHOLD = 12288
+    // Amount of bytes each pixel takes (not considering compression) at a true
+    // color bit depth
+    const PX_SIZE_BYTES = 3
+    const LIGHTHOUSE_PX_THRESHOLD = LIGHTHOUSE_BYTES_THRESHOLD / PX_SIZE_BYTES
+    // Assuming portrait (where each width increase means more pixels than if squared or landscape)
+    const PORTRAIT_ASPECT_RATIO = 16 / 9
+    const MAX_PX_BETWEEN_BREAKPOINTS = Math.floor(
+      Math.sqrt(LIGHTHOUSE_PX_THRESHOLD) * PORTRAIT_ASPECT_RATIO,
+    )
+    return new this(MAX_PX_BETWEEN_BREAKPOINTS)
   }
-  return breakpointGroups.map((breakpointGroup) => Math.max(...breakpointGroup))
+
+  public reduce(breakpoints: ReadonlyArray<number>): number[] {
+    if (!isSorted(breakpoints)) {
+      throw new Error('Breakpoints must be sorted before reducing them')
+    }
+    const reducedBreakpoints = [...breakpoints]
+    for (let i = 0; i < reducedBreakpoints.length; i++) {
+      const previous = i > 0 ? reducedBreakpoints[i - 1] : -Infinity
+      const next =
+        i + 1 < reducedBreakpoints.length ? reducedBreakpoints[i + 1] : Infinity
+      const diffBetweenNeighbours = next - previous
+      if (diffBetweenNeighbours <= this.maxPxBetweenBreakpoints) {
+        reducedBreakpoints.splice(i, 1)
+        //👇 Process next item taking into account there's an element less
+        i -= 1
+      }
+    }
+    return reducedBreakpoints
+  }
 }

--- a/src/app/common/images/responsive-image-breakpoints.ts
+++ b/src/app/common/images/responsive-image-breakpoints.ts
@@ -1,14 +1,22 @@
-import { CssPxUnit, Px } from '../css/unit/px'
-import { responsiveImageBreakpointsReducer } from './responsive-image-breakpoints-reducer'
+import { ResponsiveImageBreakpointsReducer } from './responsive-image-breakpoints-reducer'
+import { HtmlNgSrcSetAttribute } from '../html/html-ng-src-set-attribute'
 
 export class ResponsiveImageBreakpoints {
-  private constructor(public readonly list: ReadonlyArray<CssPxUnit>) {}
+  public readonly ngSrcSet = new HtmlNgSrcSetAttribute(this)
 
-  static from(list: ReadonlyArray<CssPxUnit>): ResponsiveImageBreakpoints {
-    return new this(
-      responsiveImageBreakpointsReducer(
-        list.map((breakpoint) => breakpoint.value),
-      ).map((breakpoint) => Px(breakpoint)),
+  private constructor(public readonly pxList: ReadonlyArray<number>) {}
+
+  static from(list: ReadonlyArray<number>): ResponsiveImageBreakpoints {
+    const uniqueBreakpointPxs = new Set(list)
+    const sortedUniqueBreakpointPxs = Array.from(uniqueBreakpointPxs).sort(
+      (a, b) => a - b,
+    )
+    return new this(sortedUniqueBreakpointPxs)
+  }
+
+  public reduce() {
+    return new ResponsiveImageBreakpoints(
+      ResponsiveImageBreakpointsReducer.default().reduce(this.pxList),
     )
   }
 
@@ -16,7 +24,7 @@ export class ResponsiveImageBreakpoints {
     ...others: ReadonlyArray<ResponsiveImageBreakpoints>
   ): ResponsiveImageBreakpoints {
     return ResponsiveImageBreakpoints.from(
-      [...this.list, ...others.map(({ list }) => list)].flat(),
+      [...this.pxList, ...others.map(({ pxList }) => pxList)].flat(),
     )
   }
 }

--- a/src/app/common/is-sorted.ts
+++ b/src/app/common/is-sorted.ts
@@ -1,0 +1,8 @@
+export function isSorted(array: ReadonlyArray<number>): boolean {
+  for (let i = 0; i < array.length - 1; i++) {
+    if (array[i] > array[i + 1]) {
+      return false
+    }
+  }
+  return true
+}

--- a/src/app/logo/logo.component.html
+++ b/src/app/logo/logo.component.html
@@ -5,7 +5,7 @@
     [width]="horizontalLogo.asset.width"
     [height]="horizontalLogo.asset.height"
     [priority]="true"
-    [ngSrcset]="horizontalLogo.attributes.ngSrcSet.asString"
+    [ngSrcset]="horizontalLogo.attributes.breakpoints.ngSrcSet.asString"
     [sizes]="horizontalLogo.attributes.sizes.asString"
   />
 </a>

--- a/src/app/projects/project-page/project-page.component.html
+++ b/src/app/projects/project-page/project-page.component.html
@@ -21,12 +21,17 @@
       <app-images-swiper
         *ngIf="assetsCollection.type === AssetsCollectionType.Image"
         [images]="assetsCollection.images"
-        [srcSet]="assetsCollection.imagesSwiperConfig.srcSet"
-        [sizes]="assetsCollection.imagesSwiperConfig.sizes"
+        [srcSet]="
+          assetsCollection.imagesSwiperConfig.attributes.breakpoints.ngSrcSet
+            .asString
+        "
+        [sizes]="assetsCollection.imagesSwiperConfig.attributes.sizes.asString"
         [customSwiperOptions]="
           assetsCollection.imagesSwiperConfig.customSwiperOptions
         "
-        [style.max-width.px]="assetsCollection.imagesSwiperConfig.maxWidthPx"
+        [style.max-width.px]="
+          assetsCollection.imagesSwiperConfig.maxWidth?.value
+        "
         [priority]="index < MAX_SWIPERS_PER_VIEWPORT"
       ></app-images-swiper>
     </div>

--- a/src/app/projects/project-page/project-page.component.scss
+++ b/src/app/projects/project-page/project-page.component.scss
@@ -15,6 +15,7 @@
 
   $assetsGap: margins.$m;
 
+  //👇 Keep in sync with component responsive images
   .assets {
     display: flex;
     flex-direction: column;

--- a/src/app/projects/projects-page/project-list-item/project-list-item.component.html
+++ b/src/app/projects/projects-page/project-list-item/project-list-item.component.html
@@ -20,7 +20,7 @@
     *ngIf="_item.previewImages && _item.previewImages.length"
     [images]="_item.previewImages"
     [sizes]="responsiveImageAttributes.sizes.asString"
-    [srcSet]="responsiveImageAttributes.ngSrcSet.asString"
+    [srcSet]="responsiveImageAttributes.breakpoints.ngSrcSet.asString"
     [priority]="priority"
     [customSwiperOptions]="CUSTOM_SWIPER_OPTIONS"
   ></app-images-swiper>

--- a/src/app/projects/projects-page/project-list-item/project-list-item.component.ts
+++ b/src/app/projects/projects-page/project-list-item/project-list-item.component.ts
@@ -32,11 +32,12 @@ export class ProjectListItemComponent {
     responsiveImageAttributesService: ResponsiveImageAttributesService,
   ) {
     this.responsiveImageAttributes = responsiveImageAttributesService
-      .vw(Vw(33.33))
+      .vw(Vw(33.33), CssMinMaxMediaQuery.min(Breakpoint.S.px))
       .with(
         responsiveImageAttributesService.vw(
           Vw(50),
-          CssMinMaxMediaQuery.max(Breakpoint.S.px),
+          CssMinMaxMediaQuery.max(Breakpoint.S.almost),
+          { includeMediaQueryInSizes: true },
         ),
       )
   }


### PR DESCRIPTION
Last place where breakpoints service was used! And more.

## Changes
 - Use responsive image attributes service in projects detail view
 - Add method in responsive image attributes service for images constrained to a maximum width (that don't take 100vw otherwise)
 - Add swiper base configurations, so responsive image attributes are derived from that
 - Add media queries to control breakpoints generation in all pages
 - Add include media query option in `vw` method, to control whether the media query appears in `sizes` attribute
   - So that we can leave 1 size without the media query as the default size
   - Apply convention where the default size is big screen (except for fixed width images that includes always the media query by design)
 - Use include media query option in other pages
 - Compute `ngSrcSet` and `sizes` string when creating items instead of being lazy. To avoid view generating them (which could be costly to do for every view change, and is definitely not needed)
 - Lighthouse failed several times 👁️ 
   - **Reduce API performed at last moment**: Found out that we were reducing breakpoints every time a new breakpoints list was generated (so if we have different image sizes depending on screen width, then, we have different breakpoints lists). 
     - This could cause some breakpoints to be lost despite needed
     - For instance: with max distance between breakpoints being `100px`: `reduce([100,175]) => 175`. `reduce([200,250]) => 250`. Then, `reduce([175,250]) => 250`. But 250 is 150 away from 100 one! So reduce must be done as last step.
    - **Include mobile resolutions**. Despite Lighthouse uses Moto G Power which has a [1080p resolution](https://www.gsmarena.com/motorola_moto_g_power-10076.php), the emulated dimensions when emulating device in Chrome DevTools is `412x823`. So seems it's taking that width for calculus. And therefore wants a 206 image. But closest is 160 for 320 resolution, which is very small. And next one is 425, which is almost 200px away. And Lighthouse accepts max around ~100px distance. Querying global stats, seems most resolutions are around that size in mobile. So adding most popular there (removing similar ones). Hope it works 🤞 
    - **Change breakpoints reduction algorithm** it was removing breakpoints without considering if would leave a spot > allowed between neighbours. 
    - 🥳 👆 Made the final trick