### PR TITLE
refactor(scripts): remove ts-node dependency for config

### DIFF
--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,10 +1,19 @@
-/* Dedicated to run several dev scripts with ts-node */
+/* Dedicated to run several dev scripts */
 {
-  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
-    "outDir": "dist",
+    // -- Base configs (based upon `tsc --init`)
+    //👇 Won't be emitted anyway
+    "target": "esnext",
     //👇 So we can use "bundler" resolution
     "module": "esnext",
+    //👇 Not needed :)
+    "esModuleInterop": false,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    // -- Our configs
+    "lib": ["esnext"],
+    "outDir": "dist",
     //👇 So we can use imports without extension with ESM
     "moduleResolution": "bundler",
     "resolveJsonModule": true,


### PR DESCRIPTION
Currently scripts Typescript config `tsconfig.json` depends on the recommended `ts-node` config for `node16`. To:
 - Use typescript recommendations (`tsc --init`)
 - Avoid depending on `ts-node`
 - Don't use `node16` recommended config, given we use `bun` or Node 18


A new `tsconfig.json` has been created from `tsc --init`, but tweaking settings to adapt to our use case