### PR TITLE
refactor(projects): use resolver for project page

### DIFF
--- a/src/app/common/routing/route-data-resolver.ts
+++ b/src/app/common/routing/route-data-resolver.ts
@@ -1,0 +1,3 @@
+import { ResolveFn } from '@angular/router'
+
+export type RouteDataResolver<T> = { [k in keyof T]: ResolveFn<T[k]> }

--- a/src/app/projects/project-page/project-page.component.spec.ts
+++ b/src/app/projects/project-page/project-page.component.spec.ts
@@ -2,11 +2,11 @@ import { ComponentFixture, TestBed } from '@angular/core/testing'
 
 import { ProjectPageComponent } from './project-page.component'
 import { MockComponents, MockProvider } from 'ng-mocks'
-import { ProjectsService } from '../projects.service'
 import { ImagesSwiperComponent } from '../images-swiper/images-swiper.component'
 import { of } from 'rxjs'
-import { Project } from '../project'
 import { ProjectAssetsCollectionsService } from './project-assets-collections.service'
+import { ActivatedRoute } from '@angular/router'
+import { ProjectRouteData } from './projects-routes-data'
 
 describe('ProjectPageComponent', () => {
   let component: ProjectPageComponent
@@ -19,14 +19,14 @@ describe('ProjectPageComponent', () => {
         MockComponents(ImagesSwiperComponent),
       ],
       providers: [
-        MockProvider(ProjectsService, {
-          bySlug() {
-            return of({
+        MockProvider(ActivatedRoute, {
+          data: of({
+            project: {
               title: 'Title',
               description: 'Description',
               youtubePlaylistId: 'Playlist ID',
-            } as Project)
-          },
+            },
+          } as ProjectRouteData),
         }),
         MockProvider(ProjectAssetsCollectionsService, {
           byProject() {
@@ -37,7 +37,6 @@ describe('ProjectPageComponent', () => {
     })
     fixture = TestBed.createComponent(ProjectPageComponent)
     component = fixture.componentInstance
-    component.slug = 'foo'
     fixture.detectChanges()
   })
 

--- a/src/app/projects/project-page/project-page.component.ts
+++ b/src/app/projects/project-page/project-page.component.ts
@@ -1,5 +1,4 @@
-import { Component, Input } from '@angular/core'
-import { ProjectsService } from '../projects.service'
+import { Component, OnInit } from '@angular/core'
 import { catchError, concatMap, map, Observable, of, tap } from 'rxjs'
 import { SeoService } from '@ngaox/seo'
 import { NavigatorService } from '../../common/routing/navigator.service'
@@ -19,13 +18,15 @@ import { Vw } from '../../common/css/unit/vw'
 import { CssMinMaxMediaQuery } from '../../common/css/css-min-max-media-query'
 import { Breakpoint } from '../../common/style/breakpoint'
 import { isEmpty } from 'lodash-es'
+import { ActivatedRoute } from '@angular/router'
+import { ProjectRouteData } from './projects-routes-data'
 
 @Component({
   selector: 'app-project-page',
   templateUrl: './project-page.component.html',
   styleUrls: ['./project-page.component.scss'],
 })
-export class ProjectPageComponent {
+export class ProjectPageComponent implements OnInit {
   public assetsCollections$!: Observable<ReadonlyArray<AnyAssetsCollectionItem>>
   public readonly fullScreenSwiper = {
     slidesPerView: 2,
@@ -45,7 +46,7 @@ export class ProjectPageComponent {
   protected readonly AssetsCollectionType = AssetsCollectionType
 
   constructor(
-    private projectsService: ProjectsService,
+    private activatedRoute: ActivatedRoute,
     private seo: SeoService,
     private navigatorService: NavigatorService,
     private projectAssetsCollectionsService: ProjectAssetsCollectionsService,
@@ -91,12 +92,12 @@ export class ProjectPageComponent {
     }
   }
 
-  @Input({ required: true })
-  public set slug(slug: string) {
-    const project$ = this.projectsService.bySlug(slug).pipe(
+  ngOnInit(): void {
+    const project$ = this.activatedRoute.data.pipe(
+      map((data) => (data as ProjectRouteData).project),
       tap({
         next: (project) => {
-          this.seo.setUrl(getCanonicalUrlForPath(PROJECTS_PATH, slug))
+          this.seo.setUrl(getCanonicalUrlForPath(PROJECTS_PATH, project.slug))
           this.seo.setTitle(getTitle(project.title))
           this.seo.setDescription(project.description)
         },

--- a/src/app/projects/project-page/project-page.resolver.spec.ts
+++ b/src/app/projects/project-page/project-page.resolver.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing'
+import { ProjectPageResolver } from './project-page.resolver'
+import { MockProvider } from 'ng-mocks'
+import { ProjectsService } from '../projects.service'
+
+describe('ProjectPageResolver', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [ProjectPageResolver, MockProvider(ProjectsService)],
+    })
+  })
+
+  it('should be created', () => {
+    expect(TestBed.inject(ProjectPageResolver)).toBeTruthy()
+  })
+})

--- a/src/app/projects/project-page/project-page.resolver.ts
+++ b/src/app/projects/project-page/project-page.resolver.ts
@@ -1,0 +1,32 @@
+import { ActivatedRouteSnapshot, ResolveFn } from '@angular/router'
+import { EMPTY, tap } from 'rxjs'
+import { Project } from '../project'
+import { ProjectsService } from '../projects.service'
+import { SLUG_PARAM } from '../projects-routes-params'
+import { NavigatorService } from '../../common/routing/navigator.service'
+import { Injectable } from '@angular/core'
+
+@Injectable()
+export class ProjectPageResolver {
+  constructor(
+    private projectsService: ProjectsService,
+    private navigatorService: NavigatorService,
+  ) {}
+
+  public project(
+    route: ActivatedRouteSnapshot,
+  ): ReturnType<ResolveFn<Project>> {
+    const slug = route.paramMap.get(SLUG_PARAM)
+    if (!slug) {
+      this.navigatorService.displayNotFoundPage()
+      return EMPTY
+    }
+    return this.projectsService.bySlug(slug).pipe(
+      tap({
+        error: () => {
+          this.navigatorService.displayNotFoundPage()
+        },
+      }),
+    )
+  }
+}

--- a/src/app/projects/project-page/projects-routes-data.ts
+++ b/src/app/projects/project-page/projects-routes-data.ts
@@ -1,0 +1,5 @@
+import { Project } from '../project'
+
+export interface ProjectRouteData {
+  project: Project
+}

--- a/src/app/projects/projects-routes-params.ts
+++ b/src/app/projects/projects-routes-params.ts
@@ -1,0 +1,1 @@
+export const SLUG_PARAM = 'slug'

--- a/src/app/projects/projects-routes.ts
+++ b/src/app/projects/projects-routes.ts
@@ -1,10 +1,18 @@
 import { ProjectPageComponent } from './project-page/project-page.component'
 import { Route } from '@angular/router'
+import { ProjectPageResolver } from './project-page/project-page.resolver'
+import { inject } from '@angular/core'
+import { SLUG_PARAM } from './projects-routes-params'
+import { ProjectRouteData } from './project-page/projects-routes-data'
+import { RouteDataResolver } from '../common/routing/route-data-resolver'
 
 export const PROJECTS_ROUTES: Route[] = [
   { path: '', redirectTo: '/', pathMatch: 'full' },
   {
-    path: `:slug`,
+    path: `:${SLUG_PARAM}`,
     component: ProjectPageComponent,
+    resolve: {
+      project: (route) => inject(ProjectPageResolver).project(route),
+    } as RouteDataResolver<ProjectRouteData>,
   },
 ]

--- a/src/app/projects/projects.module.ts
+++ b/src/app/projects/projects.module.ts
@@ -10,6 +10,7 @@ import { ProjectPageComponent } from './project-page/project-page.component'
 import { SanitizeResourceUrlPipe } from './sanitize-resource-url.pipe'
 import { ProjectsService } from './projects.service'
 import { ProjectAssetsCollectionsService } from './project-page/project-assets-collections.service'
+import { ProjectPageResolver } from './project-page/project-page.resolver'
 
 @NgModule({
   declarations: [
@@ -26,6 +27,10 @@ import { ProjectAssetsCollectionsService } from './project-page/project-assets-c
   // A better approach would be to declare those but there's no easy way
   // https://stackoverflow.com/a/43012920/3263250
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
-  providers: [ProjectsService, ProjectAssetsCollectionsService],
+  providers: [
+    ProjectsService,
+    ProjectAssetsCollectionsService,
+    ProjectPageResolver,
+  ],
 })
 export class ProjectsModule {}


### PR DESCRIPTION
More Angular'ish :) 

With some tweaks to schematics generated resolver:
 - Use class, instead of a pure function. This way, we can declare dependencies on constructor. Using `inject` hides dependencies declaration
 - Add a helper to generate the resolver type based on the data that will be resolved

Then:


 - Move project fetching logic from page to component
 - Fix tests