### PR TITLE
perf(projects): avoid layout shift by styling non-JS

### DIFF
--- a/src/app/projects/images-swiper/images-swiper.component.html
+++ b/src/app/projects/images-swiper/images-swiper.component.html
@@ -3,6 +3,9 @@
     <swiper-slide
       *ngFor="let image of images; index as i"
       [style.aspect-ratio]="image.width / image.height"
+      [style.min-width.%]="
+        !!_maxSlidesPerView ? 100 / _maxSlidesPerView : undefined
+      "
     >
       <img
         [ngSrc]="image.filePath"

--- a/src/app/projects/projects-page/project-list-item/project-list-item.component.scss
+++ b/src/app/projects/projects-page/project-list-item/project-list-item.component.scss
@@ -21,12 +21,14 @@
   .texts {
     display: flex;
     flex-direction: column;
+    max-width: 55ch;
   }
 
   //👇 Keep in sync with component responsive images
   app-images-swiper {
     // 👇 Seems swiper needs size set to work fine
-    width: calc(100% - $texts-width-big-screen);
+    $page-padding-horizontal: page.$padding-horizontal;
+    width: calc(100vw - $texts-width-big-screen - $page-padding-horizontal * 2);
     $extra-space: 48px;
     $available-height: content.$available-height;
     max-height: calc($available-height);
@@ -40,10 +42,12 @@
 
     .texts {
       order: 2;
+      max-width: unset;
     }
 
     app-images-swiper {
       width: 100%;
+      min-height: 300px;
       order: 1;
 
       $extra-space: 128px;


### PR DESCRIPTION
Closes #191 

Adds a bit of styling to the page so that when SwiperJs hasn't inited, layout is closer to final layout