### PR TITLE
chore: silence optimized image warnings in tests

### DIFF
--- a/src/app/about-page/about-page.component.spec.ts
+++ b/src/app/about-page/about-page.component.spec.ts
@@ -5,6 +5,7 @@ import { NgOptimizedImage } from '@angular/common'
 import { MockComponents } from 'ng-mocks'
 import { SocialComponent } from './social/social.component'
 import { ResumeComponent } from './resume/resume.component'
+import { getDummyOptimizedImageProviders } from '../../test/optimized-image'
 
 describe('AboutPageComponent', () => {
   let component: AboutPageComponent
@@ -17,6 +18,7 @@ describe('AboutPageComponent', () => {
         MockComponents(SocialComponent, ResumeComponent),
       ],
       imports: [NgOptimizedImage],
+      providers: [...getDummyOptimizedImageProviders()],
     })
     fixture = TestBed.createComponent(AboutPageComponent)
     component = fixture.componentInstance

--- a/src/app/logo/logo.component.spec.ts
+++ b/src/app/logo/logo.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { LogoComponent } from './logo.component'
 import { NgOptimizedImage } from '@angular/common'
+import { getDummyOptimizedImageProviders } from '../../test/optimized-image'
 
 describe('LogoComponent', () => {
   let component: LogoComponent
@@ -10,6 +11,7 @@ describe('LogoComponent', () => {
     TestBed.configureTestingModule({
       declarations: [LogoComponent],
       imports: [NgOptimizedImage],
+      providers: [...getDummyOptimizedImageProviders()],
     })
     fixture = TestBed.createComponent(LogoComponent)
     component = fixture.componentInstance

--- a/src/test/optimized-image.ts
+++ b/src/test/optimized-image.ts
@@ -1,0 +1,10 @@
+import { Provider } from '@angular/core'
+import { MockProvider } from 'ng-mocks'
+import { IMAGE_LOADER, PRECONNECT_CHECK_BLOCKLIST } from '@angular/common'
+
+export function getDummyOptimizedImageProviders(): Provider[] {
+  return [
+    MockProvider(IMAGE_LOADER, () => 'https://example.com/image.jpg'),
+    MockProvider(PRECONNECT_CHECK_BLOCKLIST, 'https://example.com', 'useValue'),
+  ]
+}


### PR DESCRIPTION
Otherwise was complaining about:

1. No image loader found
1. (after previous solved) No preconnect resource hint found
