### PR TITLE
perf(swiper): run outside of zone

### DIFF
--- a/src/app/projects/images-swiper/swiper.directive.ts
+++ b/src/app/projects/images-swiper/swiper.directive.ts
@@ -4,6 +4,7 @@ import {
   ElementRef,
   Inject,
   Input,
+  NgZone,
   PLATFORM_ID,
 } from '@angular/core'
 import { SwiperOptions } from 'swiper/types'
@@ -22,6 +23,7 @@ export class SwiperDirective implements AfterViewInit {
   constructor(
     private el: ElementRef<HTMLElement>,
     @Inject(PLATFORM_ID) private platformId: object,
+    private readonly ngZone: NgZone,
   ) {
     this.container = this.el.nativeElement as SwiperContainer
   }
@@ -33,7 +35,7 @@ export class SwiperDirective implements AfterViewInit {
 
     if (typeof this.container.initialize === 'function') {
       Object.assign(this.container, this.options)
-      this.container.initialize()
+      this.ngZone.runOutsideAngular(() => this.container.initialize())
     } else {
       throw new NoInitializeMethodError()
     }


### PR DESCRIPTION
Change detectiong was running too often when an image swiper was present (#201)

Turned out to be a [manual's zone pollution by a 3rd party library case](https://angular.dev/best-practices/runtime-performance). Running SwiperJS outside Angular's zone fixed it.

Trying also to enable back the Lighthouse check disabled that started appearing after adding many swipers in a page:
 - Locally seems that this doesn't fix the issue. Let's double-check on CI. But seems we'll have to tackle that in another way 😬 
 - Fails on CI too https://github.com/davidlj95/chrislb/actions/runs/7241608931/job/19725931307?pr=256

Closes #201 