### PR TITLE
build: ignore lockfile for formatter

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 src/data/**/*.json
 src/content/**/*.json
+pnpm-lock.yaml


### PR DESCRIPTION
Allows 281,282,283 to continue
