### PR TITLE
perf: replace swiper.js by glide.js

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -53,7 +53,7 @@
               "src/site.webmanifest"
             ],
             "stylePreprocessorOptions": {
-              "includePaths": ["src/sass"]
+              "includePaths": ["src/sass", "node_modules"]
             },
             "styles": [
               "src/styles.scss",
@@ -133,7 +133,7 @@
               "src/site.webmanifest"
             ],
             "stylePreprocessorOptions": {
-              "includePaths": ["src/sass"]
+              "includePaths": ["src/sass", "node_modules"]
             },
             "styles": [
               "src/styles.scss",

--- a/angular.json
+++ b/angular.json
@@ -55,14 +55,7 @@
             "stylePreprocessorOptions": {
               "includePaths": ["src/sass", "node_modules"]
             },
-            "styles": [
-              "src/styles.scss",
-              {
-                "input": "src/swiper.scss",
-                "inject": false,
-                "bundleName": "swiper"
-              }
-            ],
+            "styles": ["src/styles.scss"],
             "scripts": [],
             "browser": "src/main.ts",
             "server": "src/main.server.ts",
@@ -135,14 +128,7 @@
             "stylePreprocessorOptions": {
               "includePaths": ["src/sass", "node_modules"]
             },
-            "styles": [
-              "src/styles.scss",
-              {
-                "input": "src/swiper.scss",
-                "inject": false,
-                "bundleName": "swiper"
-              }
-            ],
+            "styles": ["src/styles.scss"],
             "scripts": []
           }
         },

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -24,6 +24,8 @@ module.exports = {
         // Just happens on project detail page tho, when many swipers there
         // Maybe a grid would solve it
         'non-composited-animations': 'warn',
+        // 👇 Most images don't have an alt text
+        'image-alt': 'off',
         'bf-cache': 'warn',
         'csp-xss': 'warn',
         'unused-javascript': 'warn',

--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
     "@fortawesome/fontawesome-svg-core": "6.7.2",
     "@fortawesome/free-brands-svg-icons": "6.7.2",
     "@fortawesome/free-solid-svg-icons": "6.7.2",
+    "@glidejs/glide": "^3.7.1",
+    "@types/glidejs__glide": "3.6.5",
     "@unpic/core": "1.0.0",
     "compression": "1.7.5",
     "express": "4.21.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint-staged": "lint-staged",
     "git-hooks": "husky",
     "cms-server": "npx decap-server",
-    "analyze-main-bundle": "ng build --source-map && npx source-map-explorer dist/chrislb/browser/main.*.js",
+    "analyze-main-bundle": "ng build --source-map && npx source-map-explorer dist/chrislb/browser/main*.js",
     "generate": "tsm scripts/src/generators/all-generators.ts",
     "generate:images-lists": "tsm scripts/src/generators/images-lists-generators.ts",
     "generate:contents": "tsm scripts/src/generators/content-generators.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,12 @@ importers:
       '@fortawesome/free-solid-svg-icons':
         specifier: 6.7.2
         version: 6.7.2
+      '@glidejs/glide':
+        specifier: ^3.7.1
+        version: 3.7.1
+      '@types/glidejs__glide':
+        specifier: 3.6.5
+        version: 3.6.5
       '@unpic/core':
         specifier: 1.0.0
         version: 1.0.0
@@ -1460,6 +1466,9 @@ packages:
     resolution: {integrity: sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==}
     engines: {node: '>=6'}
 
+  '@glidejs/glide@3.7.1':
+    resolution: {integrity: sha512-8he0pZpLSqTesSFYiuWdhBmtdlYSPWxfPUCKtkkiX6ZmT8UdMdmoFPtJaOwLBXv4p2JiGxqbuPdiRGGo2e/htQ==}
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -1996,6 +2005,9 @@ packages:
 
   '@types/express@5.0.0':
     resolution: {integrity: sha512-DvZriSMehGHL1ZNLzi6MidnsDhUZM/x2pRdDIKdwbUNqqwHxMlRdkxtn6/EPKyqKpHqTl/4nRZsRNLpZxZRpPQ==}
+
+  '@types/glidejs__glide@3.6.5':
+    resolution: {integrity: sha512-OUjzveIu+tiK5VvyPh6jTBJ/vH6+vC+XWzC2KJzpgUW8uancMJBa7R+BlXuvtSPdLw/pQForVasy0fm1D7JWOQ==}
 
   '@types/http-errors@2.0.4':
     resolution: {integrity: sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==}
@@ -7339,6 +7351,8 @@ snapshots:
     dependencies:
       '@fortawesome/fontawesome-common-types': 6.7.2
 
+  '@glidejs/glide@3.7.1': {}
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.6':
@@ -7923,6 +7937,8 @@ snapshots:
       '@types/express-serve-static-core': 5.0.3
       '@types/qs': 6.9.12
       '@types/serve-static': 1.15.5
+
+  '@types/glidejs__glide@3.6.5': {}
 
   '@types/http-errors@2.0.4': {}
 

--- a/src/app/projects/images-swiper-glidejs/images-swiper-glidejs.component.html
+++ b/src/app/projects/images-swiper-glidejs/images-swiper-glidejs.component.html
@@ -13,7 +13,7 @@
               responsiveImageAttributes().breakpoints.ngSrcSet.asString
             "
             [sizes]="responsiveImageAttributes().sizes.asString"
-            [priority]="priority() && $index < maxSlidesPerView"
+            [priority]="priority() && $index < options().slidesPerView"
             [attr.alt]="image.alt"
             fill
           />

--- a/src/app/projects/images-swiper-glidejs/images-swiper-glidejs.component.html
+++ b/src/app/projects/images-swiper-glidejs/images-swiper-glidejs.component.html
@@ -22,7 +22,11 @@
     </div>
   </div>
   <div class="glide__arrows" data-glide-el="controls">
-    <button class="glide__arrow glide__arrow--left" data-glide-dir="<">
+    <button
+      class="glide__arrow glide__arrow--left"
+      data-glide-dir="<"
+      aria-label="Previous"
+    >
       <svg
         width="11"
         height="20"
@@ -38,7 +42,11 @@
         ></path>
       </svg>
     </button>
-    <button class="glide__arrow glide__arrow--right" data-glide-dir=">">
+    <button
+      class="glide__arrow glide__arrow--right"
+      data-glide-dir=">"
+      aria-label="Next"
+    >
       <svg
         width="11"
         height="20"

--- a/src/app/projects/images-swiper-glidejs/images-swiper-glidejs.component.html
+++ b/src/app/projects/images-swiper-glidejs/images-swiper-glidejs.component.html
@@ -1,0 +1,56 @@
+<div class="glide">
+  <div class="glide__track" data-glide-el="track">
+    <div class="glide__slides">
+      @for (image of images(); track image) {
+        <div
+          class="glide__slide"
+          style="height: 100%; width: auto"
+          [style.aspect-ratio]="image.width / image.height"
+        >
+          <img
+            [ngSrc]="image.filePath"
+            [ngSrcset]="
+              responsiveImageAttributes().breakpoints.ngSrcSet.asString
+            "
+            [sizes]="responsiveImageAttributes().sizes.asString"
+            [priority]="priority() && $index < maxSlidesPerView"
+            [attr.alt]="image.alt"
+            fill
+          />
+        </div>
+      }
+    </div>
+  </div>
+  <div class="glide__arrows" data-glide-el="controls">
+    <button class="glide__arrow glide__arrow--left" data-glide-dir="<">
+      <svg
+        width="11"
+        height="20"
+        viewBox="0 0 11 20"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M0.38296 20.0762C0.111788 19.805 0.111788 19.3654 0.38296 19.0942L9.19758 10.2796L0.38296 1.46497C0.111788 1.19379 0.111788 0.754138 0.38296 0.482966C0.654131 0.211794 1.09379 0.211794 1.36496 0.482966L10.4341 9.55214C10.8359 9.9539 10.8359 10.6053 10.4341 11.007L1.36496 20.0762C1.09379 20.3474 0.654131 20.3474 0.38296 20.0762Z"
+          fill="currentColor"
+          transform-origin="center"
+          transform="rotate(180)"
+        ></path>
+      </svg>
+    </button>
+    <button class="glide__arrow glide__arrow--right" data-glide-dir=">">
+      <svg
+        width="11"
+        height="20"
+        viewBox="0 0 11 20"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M0.38296 20.0762C0.111788 19.805 0.111788 19.3654 0.38296 19.0942L9.19758 10.2796L0.38296 1.46497C0.111788 1.19379 0.111788 0.754138 0.38296 0.482966C0.654131 0.211794 1.09379 0.211794 1.36496 0.482966L10.4341 9.55214C10.8359 9.9539 10.8359 10.6053 10.4341 11.007L1.36496 20.0762C1.09379 20.3474 0.654131 20.3474 0.38296 20.0762Z"
+          fill="currentColor"
+        ></path>
+      </svg>
+    </button>
+  </div>
+</div>

--- a/src/app/projects/images-swiper-glidejs/images-swiper-glidejs.component.scss
+++ b/src/app/projects/images-swiper-glidejs/images-swiper-glidejs.component.scss
@@ -1,0 +1,52 @@
+@use 'sass:color';
+@use 'theme';
+@import '@glidejs/glide/src/assets/sass/glide.core';
+@import '@glidejs/glide/src/assets/sass/glide.theme';
+
+.glide,
+.glide__slides,
+.glide__slide,
+.glide__track {
+  height: 100%;
+}
+
+.glide__slide {
+  //👇 NgOptimizedImage's `fill` sets position to absolute
+  position: relative;
+
+  img {
+    object-fit: contain;
+  }
+}
+
+//👇 Style from Swiper.js
+//   https://github.com/nolimits4web/swiper/blob/v11.2.1/src/modules/navigation/navigation.scss
+$arrow-height: 44px;
+$arrow-width: 27px;
+$arrow-gap: 10px;
+
+.glide__arrow {
+  // 👇 Override default styles
+  margin: 0;
+  padding: 0;
+  border: none;
+  box-shadow: none;
+
+  height: $arrow-height;
+  width: $arrow-width;
+  color: theme.$accent;
+}
+
+.glide__arrow--left {
+  left: $arrow-gap;
+}
+
+.glide__arrow--left {
+  right: $arrow-gap;
+}
+
+.glide__arrow svg {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}

--- a/src/app/projects/images-swiper-glidejs/images-swiper-glidejs.component.spec.ts
+++ b/src/app/projects/images-swiper-glidejs/images-swiper-glidejs.component.spec.ts
@@ -1,0 +1,19 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+
+import { ImagesSwiperGlidejsComponent } from './images-swiper-glidejs.component'
+
+describe('ImagesSwiperGlidejsComponent', () => {
+  let component: ImagesSwiperGlidejsComponent
+  let fixture: ComponentFixture<ImagesSwiperGlidejsComponent>
+
+  beforeEach(async () => {
+    fixture = TestBed.createComponent(ImagesSwiperGlidejsComponent)
+    fixture.componentRef.setInput('images', [])
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+})

--- a/src/app/projects/images-swiper-glidejs/images-swiper-glidejs.component.ts
+++ b/src/app/projects/images-swiper-glidejs/images-swiper-glidejs.component.ts
@@ -1,0 +1,52 @@
+import {
+  afterNextRender,
+  Component,
+  effect,
+  ElementRef,
+  Injector,
+  input,
+} from '@angular/core'
+import { ImageAsset } from '../../common/images/image-asset'
+import Glide from '@glidejs/glide'
+import { NgOptimizedImage } from '@angular/common'
+import { ResponsiveImageAttributes } from '../../common/images/responsive-image-attributes'
+
+@Component({
+  selector: 'app-images-swiper-glidejs',
+  standalone: true,
+  imports: [NgOptimizedImage],
+  templateUrl: './images-swiper-glidejs.component.html',
+  styleUrl: './images-swiper-glidejs.component.scss',
+})
+export class ImagesSwiperGlidejsComponent {
+  readonly images = input.required<readonly ImageAsset[]>()
+  readonly responsiveImageAttributes =
+    input.required<ResponsiveImageAttributes>()
+  readonly priority = input(false)
+  readonly maxSlidesPerView = 2
+
+  constructor(elRef: ElementRef<HTMLElement>, injector: Injector) {
+    // TODO: Replace by afterRenderEffect. This is now a mix of
+    //        - https://stackoverflow.com/a/78272904
+    //        - https://stackoverflow.com/a/78327383
+    afterNextRender({
+      mixedReadWrite: () => {
+        const effectRef = effect(
+          () => {
+            if (this.images().length) {
+              new Glide(elRef.nativeElement, {
+                type: 'carousel',
+                perView: this.maxSlidesPerView,
+                gap: 0,
+                peek: 0,
+                autoplay: 2500,
+              }).mount()
+            }
+            effectRef.destroy()
+          },
+          { injector, manualCleanup: true },
+        )
+      },
+    })
+  }
+}

--- a/src/app/projects/images-swiper-glidejs/images-swiper-glidejs.component.ts
+++ b/src/app/projects/images-swiper-glidejs/images-swiper-glidejs.component.ts
@@ -20,10 +20,10 @@ import { ResponsiveImageAttributes } from '../../common/images/responsive-image-
 })
 export class ImagesSwiperGlidejsComponent {
   readonly images = input.required<readonly ImageAsset[]>()
+  readonly options = input.required<ImagesSwiperOptions>()
   readonly responsiveImageAttributes =
     input.required<ResponsiveImageAttributes>()
   readonly priority = input(false)
-  readonly maxSlidesPerView = 2
 
   constructor(elRef: ElementRef<HTMLElement>, injector: Injector) {
     // TODO: Replace by afterRenderEffect. This is now a mix of
@@ -36,7 +36,7 @@ export class ImagesSwiperGlidejsComponent {
             if (this.images().length) {
               new Glide(elRef.nativeElement, {
                 type: 'carousel',
-                perView: this.maxSlidesPerView,
+                perView: this.options().slidesPerView,
                 gap: 0,
                 peek: 0,
                 autoplay: 2500,
@@ -49,4 +49,8 @@ export class ImagesSwiperGlidejsComponent {
       },
     })
   }
+}
+
+export interface ImagesSwiperOptions {
+  slidesPerView: number
 }

--- a/src/app/projects/project-page/project-page.component.html
+++ b/src/app/projects/project-page/project-page.component.html
@@ -22,15 +22,13 @@
         ></iframe>
       }
       @if (assetsCollection.type === AssetsCollectionType.Image) {
-        <app-images-swiper
+        <app-images-swiper-glidejs
           [images]="assetsCollection.images"
           [responsiveImageAttributes]="assetsCollection.swiperConfig.attributes"
-          [customSwiperOptions]="
-            assetsCollection.swiperConfig.customSwiperOptions
-          "
+          [options]="assetsCollection.swiperConfig.customOptions"
           [style.max-width.px]="assetsCollection.swiperConfig.maxWidth?.value"
           [priority]="index < _maxSwipersPerViewport"
-        ></app-images-swiper>
+        ></app-images-swiper-glidejs>
       }
     </div>
   }

--- a/src/app/projects/project-page/project-page.component.scss
+++ b/src/app/projects/project-page/project-page.component.scss
@@ -23,7 +23,7 @@
     align-items: center;
     width: 100%;
 
-    > app-images-swiper {
+    > app-images-swiper-glidejs {
       width: 100%;
       //ℹ️ max-width set by component for big screens
     }

--- a/src/app/projects/project-page/project-page.component.ts
+++ b/src/app/projects/project-page/project-page.component.ts
@@ -2,7 +2,6 @@ import { Component, effect, signal } from '@angular/core'
 import { catchError, map, of } from 'rxjs'
 import { NavigatorService } from '../../common/routing/navigator.service'
 import { ProjectAssetsCollectionsService } from './project-assets-collections.service'
-import { SwiperOptions } from 'swiper/types'
 import { AssetsCollectionData } from './assets-collection-data'
 import { AssetsCollectionSize } from './assets-collection-size'
 import { AssetsCollectionType } from './assets-collection-type'
@@ -17,16 +16,19 @@ import { ProjectRouteData } from './projects-routes-data'
 import { GlobalMetadata, NgxMetaService } from '@davidlj95/ngx-meta/core'
 import { getTitle } from '../../common/routing/get-title'
 import { SanitizeResourceUrlPipe } from '../sanitize-resource-url.pipe'
-import { ImagesSwiperComponent } from '../images-swiper/images-swiper.component'
 import { toSignal } from '@angular/core/rxjs-interop'
 import { AnyAssetsCollection } from './any-asset-collection'
+import {
+  ImagesSwiperGlidejsComponent,
+  ImagesSwiperOptions,
+} from '../images-swiper-glidejs/images-swiper-glidejs.component'
 
 @Component({
   selector: 'app-project-page',
   templateUrl: './project-page.component.html',
   styleUrls: ['./project-page.component.scss'],
   standalone: true,
-  imports: [ImagesSwiperComponent, SanitizeResourceUrlPipe],
+  imports: [SanitizeResourceUrlPipe, ImagesSwiperGlidejsComponent],
   providers: [ProjectAssetsCollectionsService],
 })
 export class ProjectPageComponent {
@@ -45,7 +47,7 @@ export class ProjectPageComponent {
     ImageAssetsSwiperConfig
   > = {
     [AssetsCollectionSize.Full]: {
-      customSwiperOptions: {
+      customOptions: {
         slidesPerView: FULL_SCREEN_SWIPER.slidesPerView,
       },
       attributes: this._responsiveImageAttributesService
@@ -63,7 +65,7 @@ export class ProjectPageComponent {
       maxWidth: FULL_SCREEN_SWIPER.maxWidth,
     },
     [AssetsCollectionSize.Half]: {
-      customSwiperOptions: {
+      customOptions: {
         slidesPerView: HALF_SCREEN_SWIPER.slidesPerView,
       },
       attributes: this._responsiveImageAttributesService
@@ -128,7 +130,7 @@ export class ProjectPageComponent {
 }
 
 interface ImageAssetsSwiperConfig {
-  readonly customSwiperOptions: SwiperOptions
+  readonly customOptions: ImagesSwiperOptions
   readonly attributes: ResponsiveImageAttributes
   readonly maxWidth?: CssPxUnit
 }

--- a/src/app/projects/projects-page/project-list-item/project-list-item.component.html
+++ b/src/app/projects/projects-page/project-list-item/project-list-item.component.html
@@ -20,15 +20,17 @@
     }
     <div class="description" [innerHtml]="item().description"></div>
   </div>
-  @let previewImages = item().previewImages;
-  @if (previewImages && previewImages.length) {
-    <app-images-swiper
-      [images]="previewImages"
-      [responsiveImageAttributes]="responsiveImageAttributes"
-      [priority]="priority()"
-      [customSwiperOptions]="{ slidesPerView: 2 }"
-    ></app-images-swiper>
-  }
+  <div class="images">
+    @let previewImages = item().previewImages;
+    @if (previewImages && previewImages.length) {
+      <app-images-swiper-glidejs
+        [images]="previewImages"
+        [responsiveImageAttributes]="responsiveImageAttributes"
+        [priority]="priority()"
+      >
+      </app-images-swiper-glidejs>
+    }
+  </div>
 </div>
 @if (credits().length) {
   <div class="credits">

--- a/src/app/projects/projects-page/project-list-item/project-list-item.component.html
+++ b/src/app/projects/projects-page/project-list-item/project-list-item.component.html
@@ -25,6 +25,7 @@
     @if (previewImages && previewImages.length) {
       <app-images-swiper-glidejs
         [images]="previewImages"
+        [options]="{ slidesPerView: 2 }"
         [responsiveImageAttributes]="responsiveImageAttributes"
         [priority]="priority()"
       >

--- a/src/app/projects/projects-page/project-list-item/project-list-item.component.scss
+++ b/src/app/projects/projects-page/project-list-item/project-list-item.component.scss
@@ -2,98 +2,99 @@
 @use 'content';
 @use 'margins';
 @use 'paddings';
-@use 'page';
 @use 'typographies';
 
 :host {
   display: flex;
   flex-direction: column;
   gap: margins.$m;
+  width: 100%;
+}
 
-  .text-and-images {
-    display: flex;
-    align-content: flex-start;
-    gap: margins.$l;
+.text-and-images {
+  display: flex;
+  align-content: flex-start;
+  gap: margins.$l;
+}
+
+$texts-width-big-screen: 55ch;
+
+.texts {
+  display: flex;
+  flex-direction: column;
+  max-width: 50ch;
+  flex-shrink: 0;
+}
+
+.title {
+  @include typographies.size(8);
+  @include typographies.bold;
+
+  margin-bottom: margins.$xxs;
+}
+
+.subtitle {
+  @include typographies.size(4);
+  @include typographies.bold;
+
+  margin-bottom: margins.$l;
+}
+
+.quote {
+  @include typographies.size(1);
+  @include typographies.regular;
+
+  margin-bottom: margins.$l;
+}
+
+.description {
+  @include typographies.light;
+
+  // Keep line breaks
+  white-space: pre-wrap;
+}
+
+.credits {
+  @include typographies.regular;
+
+  display: flex;
+  flex-wrap: wrap;
+  gap: margins.$s;
+  justify-content: flex-start;
+
+  .anchor {
+    display: inline flow-root;
   }
+}
 
-  $texts-width-big-screen: 55ch;
+.images {
+  width: 100%;
+  // https://github.com/glidejs/glide/issues/233
+  min-width: 0;
+  $available-height: content.$available-height-without-header;
+  max-height: calc($available-height);
+}
+
+@include breakpoints.until-s {
+  .text-and-images {
+    flex-wrap: wrap;
+    gap: margins.$m;
+  }
 
   .texts {
-    display: flex;
-    flex-direction: column;
-    max-width: 55ch;
+    order: 2;
+    max-width: unset;
+    flex-shrink: 1;
   }
 
-  //👇 Keep in sync with component responsive images
-  app-images-swiper {
-    // 👇 Seems swiper needs size set to work fine
-    $page-padding-horizontal: page.$padding-horizontal;
-    width: calc(100vw - $texts-width-big-screen - $page-padding-horizontal * 2);
-    $extra-space: 48px;
-    $available-height: content.$available-height;
-    max-height: calc($available-height);
-  }
+  .images {
+    width: 100%;
+    min-height: 300px;
+    order: 1;
 
-  @include breakpoints.until-s {
-    .text-and-images {
-      flex-wrap: wrap;
-      gap: margins.$m;
-    }
-
-    .texts {
-      order: 2;
-      max-width: unset;
-    }
-
-    app-images-swiper {
-      width: 100%;
-      min-height: 300px;
-      order: 1;
-
-      $extra-space: 128px;
-      $available-height: content.$available-height-with-header;
-      max-height: calc($available-height - $extra-space);
-    }
-  }
-
-  .title {
-    @include typographies.size(8);
-    @include typographies.bold;
-
-    margin-bottom: margins.$xxs;
-  }
-
-  .subtitle {
-    @include typographies.size(4);
-    @include typographies.bold;
-
-    margin-bottom: margins.$l;
-  }
-
-  .quote {
-    @include typographies.size(1);
-    @include typographies.regular;
-
-    margin-bottom: margins.$l;
-  }
-
-  .description {
-    @include typographies.light;
-
-    // Keep line breaks
-    white-space: pre-wrap;
-  }
-
-  .credits {
-    @include typographies.regular;
-
-    display: flex;
-    flex-wrap: wrap;
-    gap: margins.$s;
-    justify-content: flex-start;
-
-    .anchor {
-      display: inline-block;
-    }
+    $extra-space: 128px;
+    $available-height: content.$available-height-with-header;
+    height: auto;
+    max-height: calc($available-height - $extra-space);
   }
 }

--- a/src/app/projects/projects-page/project-list-item/project-list-item.component.spec.ts
+++ b/src/app/projects/projects-page/project-list-item/project-list-item.component.spec.ts
@@ -2,7 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing'
 
 import { ProjectListItemComponent } from './project-list-item.component'
 import { MockComponents } from 'ng-mocks'
-import { ImagesSwiperComponent } from '../../images-swiper/images-swiper.component'
+import { ImagesSwiperGlidejsComponent } from '../../images-swiper-glidejs/images-swiper-glidejs.component'
 
 describe('ProjectListItemComponent', () => {
   let component: ProjectListItemComponent
@@ -11,7 +11,7 @@ describe('ProjectListItemComponent', () => {
   beforeEach(() => {
     TestBed.overrideComponent(ProjectListItemComponent, {
       set: {
-        imports: [MockComponents(ImagesSwiperComponent)],
+        imports: [MockComponents(ImagesSwiperGlidejsComponent)],
       },
     })
     fixture = TestBed.createComponent(ProjectListItemComponent)

--- a/src/app/projects/projects-page/project-list-item/project-list-item.component.ts
+++ b/src/app/projects/projects-page/project-list-item/project-list-item.component.ts
@@ -10,20 +10,20 @@ import { ResponsiveImageAttributesService } from '../../../common/images/respons
 import { Vw } from '../../../common/css/unit/vw'
 import { CssMinMaxMediaQuery } from '../../../common/css/css-min-max-media-query'
 import { Breakpoint } from '../../../common/style/breakpoint'
-import { ImagesSwiperComponent } from '../../images-swiper/images-swiper.component'
 import { RouterLink } from '@angular/router'
 import { NgTemplateOutlet } from '@angular/common'
+import { ImagesSwiperGlidejsComponent } from '../../images-swiper-glidejs/images-swiper-glidejs.component'
 
 @Component({
   selector: 'app-project-list-item',
   templateUrl: './project-list-item.component.html',
   styleUrls: ['./project-list-item.component.scss'],
   standalone: true,
-  imports: [RouterLink, NgTemplateOutlet, ImagesSwiperComponent],
+  imports: [RouterLink, NgTemplateOutlet, ImagesSwiperGlidejsComponent],
 })
 export class ProjectListItemComponent {
-  readonly priority = input(false)
   readonly item = input.required<ProjectListItem>()
+  readonly priority = input(false)
   readonly credits = computed<readonly CreditItem[]>(
     () =>
       this.item().credits?.map((credit) => {

--- a/src/sass/_content.scss
+++ b/src/sass/_content.scss
@@ -5,10 +5,10 @@
 $height-header: header.$height;
 $height-logo: logo.$height;
 $height-page-padding: page.$padding-vertical;
-$height-before-with-header: calc(
-  $height-header + $height-logo + $height-page-padding * 2
-);
 $height-before-without-header: calc($height-logo + $height-page-padding * 2);
+$height-before-with-header: calc(
+  $height-before-without-header + $height-header
+);
 
 $available-height-with-header: calc(100vh - $height-before-with-header);
-$available-height: calc(100vh - $height-before-without-header);
+$available-height-without-header: calc(100vh - $height-before-without-header);

--- a/src/swiper.scss
+++ b/src/swiper.scss
@@ -1,5 +1,0 @@
-@forward 'swiper/element/css/a11y';
-@forward 'swiper/element/css/autoplay';
-@forward 'swiper/element/css/keyboard';
-@forward 'swiper/element/css/navigation';
-@forward 'swiper/element/css/pagination';


### PR DESCRIPTION
Swiper.js is great and has lots of support from community, however comes with some performance disadvantages:
 - **Inlining critical CSS**. When using Swiper.js web component (Swiper Element), styles are [injected by referring to an external CSS file](https://swiperjs.com/element#injecting-styles). Those could be also added when initalizing the library via JS. But then we wouldn't be able to access our SCSS variables. Eventually, this doesn't allow Angular to inline that CSS in the HTML, despite it's needed as early as possible. So it's loaded later. This is because the shadow DOM that Swiper.js creates for the web component in Swiper Element. Using the core version could be an alternative. However, seems that doesn't play well with Angular as doesn't know how many slides are in there. So would need to call the API to set the slides manually when images change.
 - **Takes ~100kBs from the main bundle**. Which is quite big. Glide.js takes 26kB. Which indeed, can be reduced further by using only the needed modules in the modular build.

Glide.js solves both issues and allows a performance improvement overall.

Extra changes:
 - Fix analyze bundle run script in `package.json`

A benefit with Glide.js is that the `width` doesn't need to be explicit and works (with some hacks) with a flex box. Versus with Swiper.js that needs the width to be specified (seems so). Not sure 100% about this though!
