### PR TITLE
chore: remove selector from page components

### DIFF
--- a/src/app/about-page/about-page.component.ts
+++ b/src/app/about-page/about-page.component.ts
@@ -12,7 +12,6 @@ import { ResumeComponent } from './resume/resume.component'
 import { SocialComponent } from './social/social.component'
 
 @Component({
-  selector: 'app-about-page',
   templateUrl: './about-page.component.html',
   styleUrls: ['./about-page.component.scss'],
   standalone: true,

--- a/src/app/not-found-page/not-found-page.component.ts
+++ b/src/app/not-found-page/not-found-page.component.ts
@@ -2,7 +2,6 @@ import { Component } from '@angular/core'
 import notFoundPageMetadata from '../../data/pages/404.json'
 
 @Component({
-  selector: 'app-not-found-page',
   templateUrl: './not-found-page.component.html',
   styleUrls: ['./not-found-page.component.scss'],
   standalone: true,

--- a/src/app/projects/project-detail-page/project-detail-page.component.ts
+++ b/src/app/projects/project-detail-page/project-detail-page.component.ts
@@ -22,7 +22,6 @@ import { toSignal } from '@angular/core/rxjs-interop'
 import { AnyAssetsCollection } from './any-asset-collection'
 
 @Component({
-  selector: 'app-project-detail-page',
   templateUrl: './project-detail-page.component.html',
   styleUrls: ['./project-detail-page.component.scss'],
   standalone: true,

--- a/src/app/projects/projects-list-page/projects-list-page.component.ts
+++ b/src/app/projects/projects-list-page/projects-list-page.component.ts
@@ -6,7 +6,6 @@ import { toSignal } from '@angular/core/rxjs-interop'
 import { from } from 'rxjs'
 
 @Component({
-  selector: 'app-projects-list-page',
   templateUrl: './projects-list-page.component.html',
   styleUrls: ['./projects-list-page.component.scss'],
   standalone: true,


### PR DESCRIPTION
As those are loaded by the router, won't be included in templates, they aren't needed. The result is that the element containing is now named `<ng-component>`
