### PR TITLE
refactor: split main routes into modules

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,40 +1,14 @@
-import { ProjectsListPageComponent } from './projects/projects-list-page/projects-list-page.component'
-import { NotFoundPageComponent } from './not-found-page/not-found-page.component'
-import projectsListPageMetadata from '../data/pages/projects-list.json'
-import notFoundPageMetadata from '../data/pages/404.json'
-import { makeRouteMetadata } from './common/routing/make-route-metadata'
-import {
-  ABOUT_PATH,
-  NOT_FOUND_PATH,
-  PROJECTS_PATH,
-} from './common/routing/paths'
-import { PROJECTS_ROUTES } from './projects/projects.routes'
 import { Routes } from '@angular/router'
+import { PROJECTS_ROUTES } from './projects/projects.routes'
+import { ABOUT_PATH } from './common/routing/paths'
+import { NOT_FOUND_PAGE_ROUTES } from './not-found-page/not-found-page.routes'
 
 export const routes: Routes = [
-  {
-    path: '',
-    component: ProjectsListPageComponent,
-    data: makeRouteMetadata(projectsListPageMetadata),
-    pathMatch: 'full',
-  },
-  {
-    path: PROJECTS_PATH,
-    children: PROJECTS_ROUTES,
-  },
+  ...PROJECTS_ROUTES,
   {
     path: ABOUT_PATH,
     loadChildren: () =>
       import('./about-page/about-page.routes').then((m) => m.ABOUT_ROUTES),
   },
-  {
-    path: NOT_FOUND_PATH,
-    component: NotFoundPageComponent,
-    data: makeRouteMetadata(notFoundPageMetadata),
-  },
-  {
-    path: '**',
-    component: NotFoundPageComponent,
-    data: makeRouteMetadata(notFoundPageMetadata, [NOT_FOUND_PATH]),
-  },
+  ...NOT_FOUND_PAGE_ROUTES,
 ]

--- a/src/app/not-found-page/not-found-page.routes.ts
+++ b/src/app/not-found-page/not-found-page.routes.ts
@@ -1,0 +1,18 @@
+import { Routes } from '@angular/router'
+import { NOT_FOUND_PATH } from '../common/routing/paths'
+import { NotFoundPageComponent } from './not-found-page.component'
+import { makeRouteMetadata } from '../common/routing/make-route-metadata'
+import notFoundPageMetadata from '../../data/pages/404.json'
+
+export const NOT_FOUND_PAGE_ROUTES: Routes = [
+  {
+    path: NOT_FOUND_PATH,
+    component: NotFoundPageComponent,
+    data: makeRouteMetadata(notFoundPageMetadata),
+  },
+  {
+    path: '**',
+    component: NotFoundPageComponent,
+    data: makeRouteMetadata(notFoundPageMetadata, [NOT_FOUND_PATH]),
+  },
+]

--- a/src/app/projects/projects.routes.ts
+++ b/src/app/projects/projects.routes.ts
@@ -6,15 +6,30 @@ import { SLUG_PARAM } from './projects.routes-params'
 import { ProjectRouteData } from './project-detail-page/projects-routes-data'
 import { RouteDataResolver } from '../common/routing/route-data-resolver'
 import { ProjectsService } from './projects.service'
+import { ProjectsListPageComponent } from './projects-list-page/projects-list-page.component'
+import { makeRouteMetadata } from '../common/routing/make-route-metadata'
+import projectsListPageMetadata from '../../data/pages/projects-list.json'
+import { PROJECTS_PATH } from '../common/routing/paths'
 
 export const PROJECTS_ROUTES: Route[] = [
-  { path: '', redirectTo: '/', pathMatch: 'full' },
   {
-    path: `:${SLUG_PARAM}`,
-    component: ProjectDetailPageComponent,
-    resolve: {
-      project: (route) => inject(ProjectDetailPageResolver).project(route),
-    } as RouteDataResolver<ProjectRouteData>,
-    providers: [ProjectDetailPageResolver, ProjectsService],
+    path: '',
+    component: ProjectsListPageComponent,
+    data: makeRouteMetadata(projectsListPageMetadata),
+    pathMatch: 'full',
+  },
+  {
+    path: PROJECTS_PATH,
+    children: [
+      { path: '', redirectTo: '/', pathMatch: 'full' },
+      {
+        path: `:${SLUG_PARAM}`,
+        component: ProjectDetailPageComponent,
+        resolve: {
+          project: (route) => inject(ProjectDetailPageResolver).project(route),
+        } as RouteDataResolver<ProjectRouteData>,
+        providers: [ProjectDetailPageResolver, ProjectsService],
+      },
+    ],
   },
 ]


### PR DESCRIPTION
So that the details of each route is in each module. Otherwise root routes file looks cluttered
