### PR TITLE
refactor: define albums in CMS

### DIFF
--- a/.idea/runConfigurations/Generate__projects_content.xml
+++ b/.idea/runConfigurations/Generate__projects_content.xml
@@ -1,0 +1,12 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Generate: projects content" type="js.build_tools.npm">
+    <package-json value="$PROJECT_DIR$/package.json" />
+    <command value="run" />
+    <scripts>
+      <script value="generate:project-content" />
+    </scripts>
+    <node-interpreter value="project" />
+    <envs />
+    <method v="2" />
+  </configuration>
+</component>

--- a/data/cms/projects/bio-hangar.json
+++ b/data/cms/projects/bio-hangar.json
@@ -5,10 +5,18 @@
   "subtitle": "Denim collection",
   "quote": "Retro-futuristic vision",
   "description": "This retro-futuristic project represents an innovative fusion of past and future elements to create a distinct fashion aesthetic. The focus is on crafting garments with silver vinyl circuit-like patterns on the sleeves, evoking both nostalgia and a forward-thinking atmosphere. The core concept revolves around a technology facility from a bygone era, blending 100% cotton blue denim for vintage authenticity with futuristic silver foil accents. This juxtaposition signifies the coexistence of past and future.\n\nNotably, the garments feature a straight coat with a detachable hood, providing both weather protection and a touch of mystery by allowing wearers to see through it. The project aims to convey a sense of retro-futuristic fashion, offering a glimpse into a post-modern future. It combines the aesthetics of past eras with futuristic elements, creating a captivating collection where innovation meets nostalgia and technology harmonizes with history, weaving a compelling narrative through clothing.",
-  "lookbookNamesAndSlugs": [
+  "albums": [
     {
-      "slug": "lookbook",
-      "name": "LOOKBOOK"
+      "presetSlug": "lookbook"
+    },
+    {
+      "presetSlug": "tech-materials"
+    },
+    {
+      "presetSlug": "design-book"
+    },
+    {
+      "presetSlug": "concept"
     }
   ]
 }

--- a/data/cms/projects/chiasma.json
+++ b/data/cms/projects/chiasma.json
@@ -5,28 +5,6 @@
   "subtitle": "Final graduate collection",
   "quote": "Chiasma: crossing path of two organic structures, usually the bridge in the recombination process",
   "description": "The collection explores hybrid identity, it shows my personal experience as a second generation immigrant who has grown up between two different cultures. My Latin heritage, being born in Peru, and being raised in Spain, has led me to develop an ego that combines these two worlds in one. This experience, which is shared by many people nowadays, is redefining new identities and social principles. This project brings to the surface these experiences by exploring different acculturation profiles that are known in the process of cultural adaptation and identity development.\n\nThe masculine ego reflected in the collection is stoic and sophisticated. It is a striking ego, so outwear garments are elemental pieces and traditional masculine silhouettes are predominant. The fluidity of identity is represented through nuanced colours and prints with ethnic cultural origins. The different garments finishings emphasize the separation between the individual identity and the collective one, to see how they mix and how this cultural hybridization that I speak about is produced.",
-  "lookbookNamesAndSlugs": [
-    {
-      "slug": "ego",
-      "name": "Ego"
-    },
-    {
-      "slug": "defiant",
-      "name": "Defiant"
-    },
-    {
-      "slug": "moratorium",
-      "name": "Moratorium"
-    },
-    {
-      "slug": "foreclosure",
-      "name": "Foreclosure"
-    },
-    {
-      "slug": "diffusion",
-      "name": "Diffusion"
-    }
-  ],
   "credits": [
     {
       "role": "Photographer",
@@ -51,6 +29,42 @@
     {
       "role": "CD, Styling, process",
       "authorSlug": "christian-lazaro"
+    }
+  ],
+  "albums": [
+    {
+      "presetSlug": "lookbooks",
+      "subdirectory": "ego",
+      "customTitle": "Ego"
+    },
+    {
+      "presetSlug": "lookbooks",
+      "subdirectory": "defiant",
+      "customTitle": "Defiant"
+    },
+    {
+      "presetSlug": "lookbooks",
+      "subdirectory": "moratorium",
+      "customTitle": "Moratorium"
+    },
+    {
+      "presetSlug": "lookbooks",
+      "subdirectory": "foreclosure",
+      "customTitle": "Foreclosure"
+    },
+    {
+      "presetSlug": "lookbooks",
+      "subdirectory": "diffusion",
+      "customTitle": "Diffusion"
+    },
+    {
+      "presetSlug": "tech-materials"
+    },
+    {
+      "presetSlug": "design-book"
+    },
+    {
+      "presetSlug": "concept"
     }
   ]
 }

--- a/data/cms/projects/fresh-cut.json
+++ b/data/cms/projects/fresh-cut.json
@@ -4,10 +4,18 @@
   "title": "FRESH CUT",
   "subtitle": "Leather Capsule",
   "description": "SS capsule collection inspired by the awe-inspiring \"Chan-Chan,\" the world's largest adobe city in South America. Drawing from the geometric lines and shapes of this remarkable place, our collection infuses a fresh and contemporary vibe into its fabrics.\n\nThis exclusive collection comprises three key pieces. The set includes a beige leather bra paired with a leather and tulle fabric belt, both echoing the architectural essence of Chan-Chan. Underneath, we offer a comfortable yet stylish elastic bodysuit crafted from suede material. Each item in this collection is thoughtfully designed to capture the spirit of this extraordinary ancient city while offering a modern and fashionable touch. ",
-  "lookbookNamesAndSlugs": [
+  "albums": [
     {
-      "name": "LOOKBOOK",
-      "slug": "lookbooks"
+      "presetSlug": "lookbook"
+    },
+    {
+      "presetSlug": "tech-materials"
+    },
+    {
+      "presetSlug": "design-book"
+    },
+    {
+      "presetSlug": "concept"
     }
   ]
 }

--- a/docs/content-management/index.md
+++ b/docs/content-management/index.md
@@ -149,7 +149,7 @@ images.
 The names that will be displayed for each directory and the size of the images gallery can be changed
 in the "Album presets" content. If no definition is found for an album preset, images will not appear.
 
-> Some album presets can't be removed given they are essential for the website. Those are `preview` and `lookbooks`
+> ⚠️ `preview` album preset can't be removed given it is essential for the website
 
 > ⚠️ If the `slug` field of a project does not match **exactly** the directory name in the [image CDN]
 > inside `projects`, image won't be able to be linked.

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -153,22 +153,6 @@ collections:
       - label: 'Description'
         name: 'description'
         widget: 'text'
-      - label: 'YouTube Playlist ID'
-        name: 'youtubePlaylistId'
-        widget: 'string'
-        required: false
-        hint: 'In case you want to attach some videos, create a YouTube Playlist with those videos. Then, click on share button in the playlist. Copy and paste the link, and extract whatever comes as list ID (after the "list" parameter). For instance, a sample link could be "https://youtube.com/playlist?list=PLbAKzQYf5_ME9HVqX2laYHNWCny96L5aI&si=zjfX69n2iqzZeVN4". In there, the playlist ID is "PLbAKzQYf5_ME9HVqX2laYHNWCny96L5aI"'
-      - label: 'Lookbooks'
-        name: 'lookbookNamesAndSlugs'
-        widget: 'list'
-        summary: '{{fields.name}} ({{fields.slug}})'
-        hint: 'Allows to attach names to lookbooks and set their order when listing them all'
-        required: false
-        fields:
-          - <<: *slug
-            hint: 'Identifies the lookbook. MUST match the directory name in the image CDN. Otherwise the lookbook will appear without name and after the known lookbooks (the ones listed here)'
-          - <<: *name
-            hint: 'Name to display alongside lookbook images'
       - label: 'Credits'
         name: 'credits'
         widget: 'list'
@@ -185,6 +169,35 @@ collections:
             search_fields: ['name']
             value_field: '{{slug}}'
             display_fields: ['{{name}}']
+      - label: 'YouTube playlist ID'
+        name: 'youtubePlaylistId'
+        widget: 'string'
+        required: false
+        hint: 'In case you want to attach some videos, create a YouTube playlist with those videos. Then, click on share button in the playlist. Copy and paste the link, and extract whatever comes as list ID (after the "list" parameter). For instance, a sample link could be "https://youtube.com/playlist?list=PLbAKzQYf5_ME9HVqX2laYHNWCny96L5aI&si=zjfX69n2iqzZeVN4". In there, the playlist ID is "PLbAKzQYf5_ME9HVqX2laYHNWCny96L5aI"'
+      - label: Albums
+        name: albums
+        widget: 'list'
+        summary: '{{fields.presetSlug}}/{{fields.subdirectory}} {{fields.customTitle}}'
+        required: false
+        hint: 'An album is a set of images you want to display in the project details page. The album preset defines some configurations for it. Check album presets for more info. ‼️ Directory containing the album MUST exist, otherwise, site generation will fail. The directory containing the album images in the images CDN should be "projects/{projectSlug}/{albumPresetSlug}". With the exception of lookbooks, where in that directory multiple directories exist, one for each look'
+        fields:
+          - label: 'Album preset'
+            name: 'presetSlug'
+            widget: 'relation'
+            collection: 'album-presets'
+            search_fields: ['name']
+            value_field: '{{slug}}'
+            display_fields: ['{{name}}']
+          - label: 'Subdirectory'
+            name: 'subdirectory'
+            required: false
+            widget: 'string'
+            hint: 'If you want more than one album of the same type, you can specify the subdirectory to look for images here. Then, the images for this album should be in `projects/{projectSlug}/{albumPresetSlug}/{subdirectory}` in the images CDN'
+          - label: 'Custom title'
+            name: 'customTitle'
+            required: false
+            widget: 'string'
+            hint: 'In the case you want more than one album of the same type, maybe you want also a custom title apart from the album preset title. The final title for the album will then be: `{albumPresetTitle} {subAlbumIndex} "{customTitle}"`'
   - name: 'authors'
     label: 'Authors'
     label_singular: 'author'

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -179,7 +179,7 @@ collections:
         widget: 'list'
         summary: '{{fields.presetSlug}}/{{fields.subdirectory}} {{fields.customTitle}}'
         required: false
-        hint: 'An album is a set of images you want to display in the project details page. The album preset defines some configurations for it. Check album presets for more info. ‼️ Directory containing the album MUST exist, otherwise, site generation will fail. The directory containing the album images in the images CDN should be "projects/{projectSlug}/{albumPresetSlug}". With the exception of lookbooks, where in that directory multiple directories exist, one for each look'
+        hint: 'An album is a set of images you want to display in the project details page. The album preset defines some configurations for it. Check album presets for more info. ‼️ Directory containing the album MUST exist, otherwise, site generation will fail. The directory containing the album images in the images CDN should be "projects/{projectSlug}/{albumPresetSlug}". Except if specifying a subdirectory (see more info there)'
         fields:
           - label: 'Album preset'
             name: 'presetSlug'
@@ -256,7 +256,7 @@ collections:
         hint: 'Name of the album in the project details page'
       - <<: *slug
         label: 'Slug (directory name in image CDN)'
-        hint: '‼️ MUST match the name of the directory you will use for it inside each project in the image CDN. Otherwise, proper name will not be displayed. Lookbook specific names are specified per project'
+        hint: '‼️ MUST match the name of the directory you will use for it inside each project in the image CDN. Otherwise, proper name will not be displayed'
       - label: 'Gallery size'
         name: 'size'
         hint: 'Specifies the size for the gallery when displaying the assets in the project detail page. Full size: will take as much space as possible. This means as much height as possible on big screens or full width on small screens. Half size: assets will take half of width in big screens. On small screens, will keep taking full width'

--- a/scripts/src/generators/generate-list-files.ts
+++ b/scripts/src/generators/generate-list-files.ts
@@ -8,18 +8,13 @@ import {
   writeJson,
 } from '../utils/json'
 import { basename, join } from 'path'
-import {
-  ALBUM_PRESETS_PATH,
-  AUTHORS_PATH,
-  GENERATED_DATA_PATH,
-} from '../utils/paths'
+import { AUTHORS_PATH, GENERATED_DATA_PATH } from '../utils/paths'
 import { mkdir } from 'fs/promises'
 
 export const generateListFiles = async () => {
   await mkdir(GENERATED_DATA_PATH, { recursive: true })
   return Promise.all([
     generateListFileForDirectory(AUTHORS_PATH, ({ slug }) => ({ slug })),
-    generateListFileForDirectory(ALBUM_PRESETS_PATH),
   ])
 }
 

--- a/scripts/src/generators/generate-projects-content.ts
+++ b/scripts/src/generators/generate-projects-content.ts
@@ -3,16 +3,14 @@ import { isMain } from '../utils/is-main'
 import { Log } from '../utils/log'
 import { ImageCdnApi } from '../images/image-cdn-api'
 import PREVIEW_PRESET_JSON from '../../../data/cms/album-presets/preview.json'
-import LOOKBOOKS_PRESET_JSON from '../../../data/cms/album-presets/lookbooks.json'
-import ALBUM_PRESETS_ORDER_JSON from '../../../data/cms/misc/album-presets-order.json'
 import { ImageAsset } from '../../../src/app/common/images/image-asset'
 import {
   CmsProject,
-  ProjectAlbum,
   ProjectDetail,
+  ProjectDetailAlbum,
   ProjectListItem,
 } from '../../../src/app/projects/project'
-import { basename, join } from 'path'
+import { join } from 'path'
 import { mkdir } from 'fs/promises'
 import {
   appendJsonExtension,
@@ -24,222 +22,122 @@ import {
   ALBUM_PRESETS_PATH,
   CMS_DATA_PATH,
   CONTENT_PATH,
-  GENERATED_DATA_PATH,
   PROJECTS_CONTENT_PATH,
 } from '../utils/paths'
 import { PROJECTS_DIR } from '../../../src/app/common/directories'
 
 export const generateProjectsContent = async () => {
-  const projectsContents = await mapProjectsDataToProjectsContents()
-  await generateProjectsList(projectsContents)
-  await generateProjectsDetails(projectsContents)
+  const expandedCmsProjects = await expandCmsProjects()
+  await generateProjectsList(expandedCmsProjects)
+  await generateProjectsDetails(expandedCmsProjects)
 }
 
-// Adds images and removes unneeded fields after processing (currently just lookbook names)
-const mapProjectsDataToProjectsContents = async (): Promise<
-  readonly ProjectContent[]
-> => {
+// Adds images, reads other assets to provide the frontend app just the info it will need
+// Both for list and for details. That will be split in a later step.
+const expandCmsProjects = async (): Promise<readonly ExpandedCmsProject[]> => {
   const cmsProjectFiles = await listJsonFilesInDirectory(
     join(CMS_DATA_PATH, PROJECTS_DIR),
   )
   const imagekitApi = Imagekit.fromEnv()
-  const projectContents: ProjectContent[] = []
+  const expandedCmsProjects: ExpandedCmsProject[] = []
   for (const cmsProjectFile of cmsProjectFiles) {
-    projectContents.push(
-      await mapCmsProjectToProjectContent(imagekitApi, cmsProjectFile),
+    expandedCmsProjects.push(
+      await expandCmsProject(
+        await readJson<CmsProject>(cmsProjectFile),
+        imagekitApi,
+      ),
     )
   }
-  return projectContents
+  return expandedCmsProjects
 }
 
-const mapCmsProjectToProjectContent = async (
+const expandCmsProject = async (
+  cmsProject: CmsProject,
   imageCdnApi: ImageCdnApi,
-  cmsProjectFile: string,
-): Promise<ProjectContent> => {
-  const cmsProject = await readJson<CmsProject>(cmsProjectFile)
-  const images = await imageCdnApi.getAllImagesInPath(
-    `${PROJECTS_DIR}/${cmsProject.slug}`,
-    true,
+): Promise<ExpandedCmsProject> => {
+  const projectImageDirectory = `${PROJECTS_DIR}/${cmsProject.slug}`
+  const previewImages = await imageCdnApi.getAllImagesInPath(
+    `${projectImageDirectory}/${PREVIEW_PRESET_JSON.slug}`,
   )
-  const projectImages = images.map(
-    (image) => new ProjectImageAsset(image, cmsProject.slug),
-  )
-  const previewImages = projectImages
-    .filter(isPreviewImage)
-    .map((projectImage) => projectImage.asset)
   if (!previewImages.length) {
     throw new Error(`Project ${cmsProject.slug} has no preview images`)
   }
-  const imagesByAlbumPresetSlug = Object.groupBy(
-    projectImages.filter((projectImage) => !isPreviewImage(projectImage)),
-    (projectImage) => projectImage.presetSlug,
-  )
-  const albumPresetsFile = join(
-    GENERATED_DATA_PATH,
-    appendJsonExtension(basename(ALBUM_PRESETS_PATH)),
-  )
-  const albumPresets = await readJson<readonly AlbumPreset[]>(albumPresetsFile)
-  const albums: readonly ProjectAlbum[] = Object.entries(
-    imagesByAlbumPresetSlug,
-  )
-    .map<readonly ProjectAlbumWithPresetSlug[]>(
-      ([presetSlug, projectImages]) => {
-        const isLookbooks = presetSlug === LOOKBOOKS_PRESET_JSON.slug
-        const images = projectImages!.map((projectImage) => projectImage.asset)
-        const preset = albumPresets.find(({ slug }) => presetSlug === slug)
-        if (!preset) {
-          Log.warn(
-            `Skipping ${cmsProject.slug} project album ${presetSlug} path in CDN. It is not a recognized album preset`,
-          )
-          return []
-        }
-        if (!isLookbooks) {
-          const imagesWithinSubdirs = projectImages!.filter(
-            ({ subdir }) => subdir,
-          )
-          if (imagesWithinSubdirs.length) {
-            Log.warn(
-              `${cmsProject.slug} project album ${presetSlug} path has images inside subdirectories. That's not expected though. Ignoring for now anyway`,
-            )
-          }
-          return [
-            {
-              title: preset.name,
-              images,
-              size: preset.size as ProjectAlbum['size'],
-              presetSlug: preset.slug,
-            },
-          ]
-        }
-        const projectImagesByLookbook = Object.groupBy(
-          projectImages!,
-          (projectImage) => projectImage.subdir,
-        )
-        return Object.entries(
-          projectImagesByLookbook,
-        ).map<ProjectAlbumWithPresetSlug>(([lookbookSlug, projectImages]) => {
-          const lookbookIndex = cmsProject.lookbookNamesAndSlugs!.findIndex(
-            (lookbookNameAndSlug) => lookbookNameAndSlug.slug === lookbookSlug,
-          )
-          if (lookbookIndex === -1) {
-            throw new Error(
-              `No title for named lookbook ${lookbookSlug} in project ${cmsProject.slug}`,
-            )
-          }
-          const lookbookNameAndSlug =
-            cmsProject.lookbookNamesAndSlugs![lookbookIndex]
-          return {
-            title: `${LOOKBOOKS_PRESET_JSON.name} ${lookbookIndex + 1} "${lookbookNameAndSlug.name}"`,
-            images: projectImages!.map((projectImage) => projectImage.asset),
-            size: LOOKBOOKS_PRESET_JSON.size as ProjectAlbum['size'],
-            presetSlug: LOOKBOOKS_PRESET_JSON.slug,
-          }
-        })
-      },
+  const albums: ProjectDetailAlbum[] = []
+  for (const cmsProjectAlbum of cmsProject.albums ?? []) {
+    const preset = await getPresetBySlug(cmsProjectAlbum.presetSlug)
+    const albumPresetImageDirectory = `${projectImageDirectory}/${preset.slug}`
+    const albumImageDirectory = cmsProjectAlbum.subdirectory
+      ? `${albumPresetImageDirectory}/${cmsProjectAlbum.subdirectory}`
+      : albumPresetImageDirectory
+    const images = await imageCdnApi.getAllImagesInPath(
+      albumImageDirectory,
+      false,
     )
-    .flat()
-    .sort((albumA, albumB) => {
-      if (isCustomLookbookAlbum(albumA) && isCustomLookbookAlbum(albumB)) {
-        //👇 Given title contains index. Won't work for <9 looks
-        return albumA.title < albumB.title ? -1 : 1
-      }
-      const [albumAPresetIndex, albumBPresetIndex] = [
-        albumA.presetSlug,
-        albumB.presetSlug,
-      ].map((preset) => {
-        const presetIndex =
-          ALBUM_PRESETS_ORDER_JSON.albumPresetsOrder.indexOf(preset)
-        if (presetIndex === -1) {
-          throw new Error(
-            `Can't sort ${cmsProject.slug} album with preset ${preset}. Cannot find position for preset`,
-          )
-        }
-        return presetIndex
-      })
-      return albumAPresetIndex - albumBPresetIndex
+    const albumsWithSamePreset = (cmsProject.albums ?? []).filter(
+      (album) => album.presetSlug === cmsProjectAlbum.presetSlug,
+    )
+    const albumIndex = albumsWithSamePreset.indexOf(cmsProjectAlbum) + 1
+    const title =
+      albumsWithSamePreset.length > 1
+        ? cmsProjectAlbum.customTitle
+          ? `${preset.name} ${albumIndex} "${cmsProjectAlbum.customTitle}"`
+          : `${preset.name} ${albumIndex}`
+        : cmsProjectAlbum.customTitle
+          ? `${preset.name} "${cmsProjectAlbum.customTitle}"`
+          : preset.name
+    albums.push({
+      title,
+      images,
+      size: preset.size,
     })
-    .map<ProjectAlbum>((albumWithPreset) => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { presetSlug, ...albumWithoutPreset } = albumWithPreset
-      return albumWithoutPreset
-    })
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { lookbookNamesAndSlugs, ...contentProjectJsonBase } = cmsProject
+  }
   return {
-    ...contentProjectJsonBase,
+    ...cmsProject,
     previewImages,
     albums,
   }
 }
 
-interface AlbumPreset {
+const PRESETS_BY_SLUG = new Map<string, CmsAlbumPreset>()
+const getPresetBySlug = async (slug: string): Promise<CmsAlbumPreset> => {
+  const cachedPreset = PRESETS_BY_SLUG.get(slug)
+  if (cachedPreset) {
+    return cachedPreset
+  }
+  const preset = await readJson<CmsAlbumPreset>(
+    join(ALBUM_PRESETS_PATH, appendJsonExtension(slug)),
+  )
+  PRESETS_BY_SLUG.set(slug, preset)
+  return preset
+}
+
+interface CmsAlbumPreset {
   readonly name: string
   readonly slug: string
-  readonly size: ProjectAlbum['size']
+  readonly size: ProjectDetailAlbum['size']
 }
 
-export class ProjectImageAsset {
-  private _relativeFilePath?: string
-
-  constructor(
-    readonly asset: ImageAsset,
-    readonly projectSlug: string,
-  ) {}
-
-  get presetSlug(): string {
-    const relativeFilePathParts = this.relativeFilePath.split('/')
-    if (relativeFilePathParts.length < 2) {
-      return ''
-    }
-    return relativeFilePathParts[0]
-  }
-
-  get subdir(): string {
-    const relativeFilePathParts = this.relativeFilePath.split('/')
-    if (relativeFilePathParts.length < 3) {
-      return ''
-    }
-    return relativeFilePathParts[1]
-  }
-
-  get relativeFilePath() {
-    if (!this._relativeFilePath) {
-      this._relativeFilePath = this.asset.filePath
-        .replace(/^\//, '')
-        .replace(new RegExp(`^${PROJECTS_DIR}/`), '')
-        .replace(new RegExp(`^${this.projectSlug}/`), '')
-    }
-    return this._relativeFilePath
-  }
-}
-
-const isPreviewImage = (projectImage: ProjectImageAsset) =>
-  projectImage.presetSlug === PREVIEW_PRESET_JSON.slug
-
-const isCustomLookbookAlbum = (album: ProjectAlbumWithPresetSlug) =>
-  album.presetSlug === LOOKBOOKS_PRESET_JSON.slug && album.title
-
-export type ProjectContent = Omit<CmsProject, 'lookbookNamesAndSlugs'> & {
+export type ExpandedCmsProject = Omit<CmsProject, 'albums'> & {
   readonly previewImages: readonly ImageAsset[]
-  readonly albums: readonly ProjectAlbum[]
+  readonly albums: readonly ProjectDetailAlbum[]
 }
-
-export type ProjectAlbumWithPresetSlug = ProjectAlbum & { presetSlug: string }
 
 const generateProjectsList = async (
-  projectsContents: readonly ProjectContent[],
+  expandedCmsProjects: readonly ExpandedCmsProject[],
 ) => {
-  const projectListItems = projectsContents
-    .map<ProjectListItem & Pick<ProjectContent, 'date'>>((projectContent) => {
-      //👇 To remove unneeded props, they are assigned but unused
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const { albums, youtubePlaylistId, ...baseProjectListItem } =
-        projectContent
-      return {
-        ...baseProjectListItem,
-        hasDetails: hasDetails(projectContent),
-      }
-    })
+  const projectListItems = expandedCmsProjects
+    .map<ProjectListItem & Pick<ExpandedCmsProject, 'date'>>(
+      (expandedCmsProject) => {
+        //👇 To remove unneeded props, they are assigned but unused
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { albums, youtubePlaylistId, ...baseProjectListItem } =
+          expandedCmsProject
+        return {
+          ...baseProjectListItem,
+          hasDetails: hasDetails(expandedCmsProject),
+        }
+      },
+    )
     .sort(
       (projectA, projectB) =>
         new Date(projectB.date).getTime() - new Date(projectA.date).getTime(),
@@ -256,38 +154,33 @@ const generateProjectsList = async (
   )
 }
 
-export const hasDetails = (projectContent: ProjectContent) =>
+const hasDetails = (projectContent: ExpandedCmsProject) =>
   !!projectContent.youtubePlaylistId || !!projectContent.albums.length
 
 const generateProjectsDetails = async (
-  projectsContents: readonly ProjectContent[],
+  expandedCmsProjects: readonly ExpandedCmsProject[],
 ) => {
   await mkdir(PROJECTS_CONTENT_PATH, { recursive: true })
-  return Promise.all(projectsContents.map(generateProjectDetail))
+  return Promise.all(expandedCmsProjects.map(generateProjectDetail))
 }
 
-const generateProjectDetail = (projectContent: ProjectContent) => {
-  if (!hasDetails(projectContent)) {
+const generateProjectDetail = (expandedCmsProject: ExpandedCmsProject) => {
+  if (!hasDetails(expandedCmsProject)) {
     return
   }
-  return writeJson(
-    join(PROJECTS_CONTENT_PATH, appendJsonExtension(projectContent.slug)),
-    mapProjectContentToProjectDetails(projectContent),
-  )
-}
-
-const mapProjectContentToProjectDetails = (
-  projectContent: ProjectContent,
-): ProjectDetail => {
   const { title, quote, description, youtubePlaylistId, albums } =
-    projectContent
-  return {
+    expandedCmsProject
+  const projectDetail: ProjectDetail = {
     title,
     quote,
     description: quote ? undefined : description,
     youtubePlaylistId,
     albums: albums.length ? albums : undefined,
   }
+  return writeJson(
+    join(PROJECTS_CONTENT_PATH, appendJsonExtension(expandedCmsProject.slug)),
+    projectDetail,
+  )
 }
 
 if (isMain(import.meta.url)) {

--- a/src/app/projects/lookbook-name-and-slug.ts
+++ b/src/app/projects/lookbook-name-and-slug.ts
@@ -1,4 +1,0 @@
-export interface LookbookNameAndSlug {
-  readonly slug: string
-  readonly name: string
-}

--- a/src/app/projects/project-detail-page/project-detail-page.component.ts
+++ b/src/app/projects/project-detail-page/project-detail-page.component.ts
@@ -14,7 +14,7 @@ import { getTitle } from '../../common/routing/get-title'
 import { SanitizeResourceUrlPipe } from '../sanitize-resource-url.pipe'
 import { ImagesSwiperComponent } from '../images-swiper/images-swiper.component'
 import { toSignal } from '@angular/core/rxjs-interop'
-import { ProjectAlbum, ProjectDetail } from '../project'
+import { ProjectDetail, ProjectDetailAlbum } from '../project'
 
 @Component({
   templateUrl: './project-detail-page.component.html',
@@ -59,7 +59,7 @@ export class ProjectDetailPageComponent {
   protected readonly _maxSwipersPerViewport = 2
 
   private readonly _albumSwiperByPresetSize: Record<
-    ProjectAlbum['size'],
+    ProjectDetailAlbum['size'],
     ProjectAlbumSwiper
   > = {
     full: {
@@ -132,7 +132,7 @@ const getDescription = ({
   }
 }
 
-type ProjectAlbumViewModel = ProjectAlbum & {
+type ProjectAlbumViewModel = ProjectDetailAlbum & {
   readonly swiper: ProjectAlbumSwiper
 }
 

--- a/src/app/projects/project.ts
+++ b/src/app/projects/project.ts
@@ -1,20 +1,5 @@
-import { LookbookNameAndSlug } from './lookbook-name-and-slug'
 import { Credit } from './credit'
 import { ImageAsset } from '../common/images/image-asset'
-
-export interface Project {
-  readonly slug: string
-  readonly date: string
-  readonly title: string
-  readonly subtitle: string
-  readonly quote?: string
-  readonly description: string
-  readonly youtubePlaylistId?: string
-  readonly lookbookNamesAndSlugs?: readonly LookbookNameAndSlug[]
-  //👇 When hasn't been set, CMS doesn't set the property
-  //   CMS sets it after though (if adding & removing)
-  readonly credits?: readonly Credit[]
-}
 
 export interface CmsProject {
   readonly slug: string
@@ -24,10 +9,16 @@ export interface CmsProject {
   readonly quote?: string
   readonly description: string
   readonly youtubePlaylistId?: string
-  readonly lookbookNamesAndSlugs?: readonly LookbookNameAndSlug[]
   //👇 When hasn't been set, CMS doesn't set the property
   //   CMS sets it after though (if adding & removing)
   readonly credits?: readonly Credit[]
+  readonly albums?: readonly CmsProjectAlbum[]
+}
+
+export interface CmsProjectAlbum {
+  readonly presetSlug: string
+  readonly subdirectory?: string
+  readonly customTitle?: string
 }
 
 export type ProjectListItem = Omit<
@@ -39,11 +30,12 @@ export type ProjectListItem = Omit<
 }
 
 export type ProjectDetail = Pick<CmsProject, 'title' | 'youtubePlaylistId'> & {
-  readonly albums?: readonly ProjectAlbum[]
+  readonly albums?: readonly ProjectDetailAlbum[]
 } & Partial<Pick<CmsProject, 'description' | 'quote'>>
 
-export interface ProjectAlbum {
+export interface ProjectDetailAlbum {
   title: string
   images: readonly ImageAsset[]
+  //👇 Keep in sync with CMS
   size: 'half' | 'full'
 }

--- a/src/app/projects/project.ts
+++ b/src/app/projects/project.ts
@@ -23,7 +23,7 @@ export interface CmsProjectAlbum {
 
 export type ProjectListItem = Omit<
   CmsProject,
-  'date' | 'lookbookNamesAndSlugs' | 'albums' | 'youtubePlaylistId'
+  'date' | 'albums' | 'youtubePlaylistId'
 > & {
   previewImages: readonly ImageAsset[]
   hasDetails: boolean


### PR DESCRIPTION
To keep simplifying scripts. Plus later be able to specify images in CDN if needed. Now images are loaded into a project by looking for all assets inside the project directory `projects/{projectSlug}`. Directories whose name match one of the album presets will be taken into account as albums. However, that implies looking for all directories inside images CDN and then match directories. If that's instead specified in the CMS, no need to search and match. 

Another win if specifying in the CMS the albums, it's that they can be sorted in there. So no need for the album presets order collection.

Also lookbooks management has been simplified and made a bit more generic. By allowing an album to a) use a subdirectory of the album preset directory b) specify a custom title. Then, scripts are updated to add the index to the album title if more than one album with same preset is found.

Finally, `ProjectCms` interface has been renamed to `CmsProject`. Because the interface defines a project specified in the CMS, and not the other way around.

As an extra, to reduce calls to open files, the script to generate projects caches reads to presets files to avoid reading them multiple times from disk.
