### PR TITLE
perf: remove zone.js

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -37,7 +37,6 @@
               "base": "dist/chrislb"
             },
             "index": "src/index.html",
-            "polyfills": ["zone.js"],
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
             "assets": [
@@ -111,7 +110,6 @@
         "test": {
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
-            "polyfills": ["zone.js", "zone.js/testing"],
             "tsConfig": "tsconfig.spec.json",
             "inlineStyleLanguage": "scss",
             "assets": [

--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
     "lodash-es": "4.17.21",
     "rxjs": "7.8.2",
     "swiper": "11.2.5",
-    "tslib": "2.8.1",
-    "zone.js": "0.14.10"
+    "tslib": "2.8.1"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "18.2.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,9 +80,6 @@ importers:
       tslib:
         specifier: 2.8.1
         version: 2.8.1
-      zone.js:
-        specifier: 0.14.10
-        version: 0.14.10
     devDependencies:
       '@angular-devkit/build-angular':
         specifier: 18.2.12

--- a/src/app/about-page/about-page.component.spec.ts
+++ b/src/app/about-page/about-page.component.spec.ts
@@ -6,13 +6,14 @@ import { SocialComponent } from './social/social.component'
 import { ResumeComponent } from './resume/resume.component'
 import { provideDummyOptimizedImage } from '../../test/provide-dummy-optimized-image'
 import { NgOptimizedImage } from '@angular/common'
+import { testbedSetup } from '../../test/testbed-setup'
 
 describe('AboutPageComponent', () => {
   let component: AboutPageComponent
   let fixture: ComponentFixture<AboutPageComponent>
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
+    testbedSetup({
       providers: [provideDummyOptimizedImage()],
     })
     TestBed.overrideComponent(AboutPageComponent, {

--- a/src/app/about-page/resume/resume.component.spec.ts
+++ b/src/app/about-page/resume/resume.component.spec.ts
@@ -3,12 +3,14 @@ import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { ResumeComponent } from './resume.component'
 import { MockComponents } from 'ng-mocks'
 import { FaIconComponent } from '@fortawesome/angular-fontawesome'
+import { testbedSetup } from '../../../test/testbed-setup'
 
 describe('ResumeComponent', () => {
   let component: ResumeComponent
   let fixture: ComponentFixture<ResumeComponent>
 
   beforeEach(() => {
+    testbedSetup()
     TestBed.overrideComponent(ResumeComponent, {
       set: {
         imports: [MockComponents(FaIconComponent)],

--- a/src/app/about-page/social/social.component.spec.ts
+++ b/src/app/about-page/social/social.component.spec.ts
@@ -3,12 +3,14 @@ import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { SocialComponent } from './social.component'
 import { MockComponents } from 'ng-mocks'
 import { FaIconComponent } from '@fortawesome/angular-fontawesome'
+import { testbedSetup } from '../../../test/testbed-setup'
 
 describe('SocialComponent', () => {
   let component: SocialComponent
   let fixture: ComponentFixture<SocialComponent>
 
   beforeEach(() => {
+    testbedSetup()
     TestBed.overrideComponent(SocialComponent, {
       set: {
         imports: [MockComponents(FaIconComponent)],

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -4,9 +4,11 @@ import { MockComponents } from 'ng-mocks'
 import { HeaderComponent } from './header/header.component'
 import { LogoComponent } from './logo/logo.component'
 import { RouterOutlet } from '@angular/router'
+import { testbedSetup } from '../test/testbed-setup'
 
 describe('AppComponent', () => {
   beforeEach(() => {
+    testbedSetup()
     TestBed.overrideComponent(AppComponent, {
       set: {
         imports: [RouterOutlet, MockComponents(HeaderComponent, LogoComponent)],

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,4 +1,7 @@
-import { ApplicationConfig } from '@angular/core'
+import {
+  ApplicationConfig,
+  provideExperimentalZonelessChangeDetection,
+} from '@angular/core'
 import { APP_BASE_HREF, provideImageKitLoader } from '@angular/common'
 import {
   ANGULAR_ROUTER_URL,
@@ -64,5 +67,6 @@ export const appConfig: ApplicationConfig = {
     provideNgxMetaOpenGraph(),
     provideAnimationsAsync(),
     provideHttpClient(),
+    provideExperimentalZonelessChangeDetection(),
   ],
 }

--- a/src/app/common/images/responsive-image-attributes.service.spec.ts
+++ b/src/app/common/images/responsive-image-attributes.service.spec.ts
@@ -1,11 +1,13 @@
 import { TestBed } from '@angular/core/testing'
 
 import { ResponsiveImageAttributesService } from './responsive-image-attributes.service'
+import { testbedSetup } from '../../../test/testbed-setup'
 
 describe('ResponsiveImageService', () => {
   let service: ResponsiveImageAttributesService
 
   beforeEach(() => {
+    testbedSetup()
     service = TestBed.inject(ResponsiveImageAttributesService)
   })
 

--- a/src/app/common/json-fetcher/http-json-fetcher.service.spec.ts
+++ b/src/app/common/json-fetcher/http-json-fetcher.service.spec.ts
@@ -5,12 +5,13 @@ import { provideHttpClientTesting } from '@angular/common/http/testing'
 import { MockProvider } from 'ng-mocks'
 import { APP_BASE_HREF } from '@angular/common'
 import { provideHttpClient } from '@angular/common/http'
+import { testbedSetup } from '../../../test/testbed-setup'
 
 describe('HttpJsonFetcherService', () => {
   let service: HttpJsonFetcherService
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
+    testbedSetup({
       providers: [
         MockProvider(APP_BASE_HREF, '/'),
         provideHttpClient(),

--- a/src/app/common/routing/navigator.service.spec.ts
+++ b/src/app/common/routing/navigator.service.spec.ts
@@ -1,11 +1,13 @@
 import { TestBed } from '@angular/core/testing'
 
 import { NavigatorService } from './navigator.service'
+import { testbedSetup } from '../../../test/testbed-setup'
 
 describe('NavigatorService', () => {
   let service: NavigatorService
 
   beforeEach(() => {
+    testbedSetup()
     service = TestBed.inject(NavigatorService)
   })
 

--- a/src/app/header/header.component.spec.ts
+++ b/src/app/header/header.component.spec.ts
@@ -2,13 +2,14 @@ import { ComponentFixture, TestBed } from '@angular/core/testing'
 
 import { HeaderComponent } from './header.component'
 import { provideRouter } from '@angular/router'
+import { testbedSetup } from '../../test/testbed-setup'
 
 describe('HeaderComponent', () => {
   let component: HeaderComponent
   let fixture: ComponentFixture<HeaderComponent>
 
   beforeEach(() => {
-    TestBed.configureTestingModule({ providers: [provideRouter([])] })
+    testbedSetup({ providers: [provideRouter([])] })
     fixture = TestBed.createComponent(HeaderComponent)
     component = fixture.componentInstance
     fixture.detectChanges()

--- a/src/app/logo/logo.component.spec.ts
+++ b/src/app/logo/logo.component.spec.ts
@@ -2,13 +2,14 @@ import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { LogoComponent } from './logo.component'
 import { provideRouter } from '@angular/router'
 import { provideDummyOptimizedImage } from '../../test/provide-dummy-optimized-image'
+import { testbedSetup } from '../../test/testbed-setup'
 
 describe('LogoComponent', () => {
   let component: LogoComponent
   let fixture: ComponentFixture<LogoComponent>
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
+    testbedSetup({
       providers: [provideRouter([]), provideDummyOptimizedImage()],
     })
     fixture = TestBed.createComponent(LogoComponent)

--- a/src/app/not-found-page/not-found-page.component.spec.ts
+++ b/src/app/not-found-page/not-found-page.component.spec.ts
@@ -1,12 +1,14 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 
 import { NotFoundPageComponent } from './not-found-page.component'
+import { testbedSetup } from '../../test/testbed-setup'
 
 describe('NotFoundPageComponent', () => {
   let component: NotFoundPageComponent
   let fixture: ComponentFixture<NotFoundPageComponent>
 
   beforeEach(() => {
+    testbedSetup()
     fixture = TestBed.createComponent(NotFoundPageComponent)
     component = fixture.componentInstance
     fixture.detectChanges()

--- a/src/app/projects/images-swiper/images-swiper.component.spec.ts
+++ b/src/app/projects/images-swiper/images-swiper.component.spec.ts
@@ -1,12 +1,14 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing'
 
 import { ImagesSwiperComponent } from './images-swiper.component'
+import { testbedSetup } from '../../../test/testbed-setup'
 
 describe('ImagesSwiperComponent', () => {
   let component: ImagesSwiperComponent
   let fixture: ComponentFixture<ImagesSwiperComponent>
 
   beforeEach(() => {
+    testbedSetup()
     fixture = TestBed.createComponent(ImagesSwiperComponent)
     fixture.componentRef.setInput('images', [])
     component = fixture.componentInstance

--- a/src/app/projects/images-swiper/swiper.directive.spec.ts
+++ b/src/app/projects/images-swiper/swiper.directive.spec.ts
@@ -11,6 +11,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { SwiperDirective } from './swiper.directive'
 import { By } from '@angular/platform-browser'
 import { SwiperContainer } from 'swiper/swiper-element'
+import { testbedSetup } from '../../../test/testbed-setup'
 
 describe('SwiperDirective', () => {
   const options: SwiperOptions = {
@@ -90,7 +91,7 @@ function makeSut<T>({
 }: {
   component: Type<T>
 }): [ComponentFixture<T>, T] {
-  TestBed.configureTestingModule({
+  testbedSetup({
     schemas: [CUSTOM_ELEMENTS_SCHEMA],
   })
   const fixture = TestBed.createComponent(component)

--- a/src/app/projects/project-detail-page/project-detail-page.component.spec.ts
+++ b/src/app/projects/project-detail-page/project-detail-page.component.spec.ts
@@ -8,13 +8,14 @@ import { ActivatedRoute } from '@angular/router'
 import { ProjectDetailRouteData } from './projects-routes-data'
 import { NgxMetaService } from '@davidlj95/ngx-meta/core'
 import { SanitizeResourceUrlPipe } from '../sanitize-resource-url.pipe'
+import { testbedSetup } from '../../../test/testbed-setup'
 
 describe('ProjectDetailPageComponent', () => {
   let component: ProjectDetailPageComponent
   let fixture: ComponentFixture<ProjectDetailPageComponent>
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
+    testbedSetup({
       providers: [
         MockProvider(ActivatedRoute, {
           data: of({

--- a/src/app/projects/project-detail-page/project-detail-page.resolver.spec.ts
+++ b/src/app/projects/project-detail-page/project-detail-page.resolver.spec.ts
@@ -2,10 +2,11 @@ import { TestBed } from '@angular/core/testing'
 import { ProjectDetailPageResolver } from './project-detail-page-resolver.service'
 import { MockProvider } from 'ng-mocks'
 import { ProjectsService } from '../projects.service'
+import { testbedSetup } from '../../../test/testbed-setup'
 
 describe('ProjectDetailPageResolver', () => {
   beforeEach(() => {
-    TestBed.configureTestingModule({
+    testbedSetup({
       providers: [ProjectDetailPageResolver, MockProvider(ProjectsService)],
     })
   })

--- a/src/app/projects/projects-list-page/project-list-item/project-list-item.component.spec.ts
+++ b/src/app/projects/projects-list-page/project-list-item/project-list-item.component.spec.ts
@@ -3,12 +3,14 @@ import { ComponentFixture, TestBed } from '@angular/core/testing'
 import { ProjectListItemComponent } from './project-list-item.component'
 import { MockComponents } from 'ng-mocks'
 import { ImagesSwiperComponent } from '../../images-swiper/images-swiper.component'
+import { testbedSetup } from '../../../../test/testbed-setup'
 
 describe('ProjectListItemComponent', () => {
   let component: ProjectListItemComponent
   let fixture: ComponentFixture<ProjectListItemComponent>
 
   beforeEach(() => {
+    testbedSetup()
     TestBed.overrideComponent(ProjectListItemComponent, {
       set: {
         imports: [MockComponents(ImagesSwiperComponent)],

--- a/src/app/projects/projects-list-page/projects-list-page.component.spec.ts
+++ b/src/app/projects/projects-list-page/projects-list-page.component.spec.ts
@@ -4,12 +4,14 @@ import { ProjectsListPageComponent } from './projects-list-page.component'
 import { MockComponents, MockProvider } from 'ng-mocks'
 import { ProjectListItemComponent } from './project-list-item/project-list-item.component'
 import { ProjectsService } from '../projects.service'
+import { testbedSetup } from '../../../test/testbed-setup'
 
 describe('ProjectsListPageComponent', () => {
   let component: ProjectsListPageComponent
   let fixture: ComponentFixture<ProjectsListPageComponent>
 
   beforeEach(() => {
+    testbedSetup()
     TestBed.overrideComponent(ProjectsListPageComponent, {
       set: {
         imports: [MockComponents(ProjectListItemComponent)],

--- a/src/app/projects/projects.service.spec.ts
+++ b/src/app/projects/projects.service.spec.ts
@@ -3,12 +3,13 @@ import { TestBed } from '@angular/core/testing'
 import { ProjectsService } from './projects.service'
 import { JsonFetcher } from '../common/json-fetcher/json-fetcher'
 import { MockProviders } from 'ng-mocks'
+import { testbedSetup } from '../../test/testbed-setup'
 
 describe('ProjectsService', () => {
   let service: ProjectsService
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
+    testbedSetup({
       providers: [ProjectsService, MockProviders(JsonFetcher)],
     })
     service = TestBed.inject(ProjectsService)

--- a/src/app/projects/sanitize-resource-url.pipe.spec.ts
+++ b/src/app/projects/sanitize-resource-url.pipe.spec.ts
@@ -1,9 +1,11 @@
 import { SanitizeResourceUrlPipe } from './sanitize-resource-url.pipe'
 import { TestBed } from '@angular/core/testing'
 import { DomSanitizer } from '@angular/platform-browser'
+import { testbedSetup } from '../../test/testbed-setup'
 
 describe('SanitizeResourceUrlPipe', () => {
   it('create an instance', () => {
+    testbedSetup()
     const sanitizer = TestBed.inject(DomSanitizer)
     const pipe = new SanitizeResourceUrlPipe(sanitizer)
     expect(pipe).toBeTruthy()

--- a/src/test/testbed-setup.ts
+++ b/src/test/testbed-setup.ts
@@ -1,0 +1,14 @@
+import { provideExperimentalZonelessChangeDetection } from '@angular/core'
+import { TestBed } from '@angular/core/testing'
+
+export const testbedSetup = (
+  opts: Parameters<typeof TestBed.configureTestingModule>[0] = {},
+) => {
+  TestBed.configureTestingModule({
+    ...opts,
+    providers: [
+      provideExperimentalZonelessChangeDetection(),
+      ...(opts.providers ?? []),
+    ],
+  })
+}


### PR DESCRIPTION
After migrating to Cloudinary, seems that responsive images have improved. However now it's failing (and it's quite bad in `main`) due to lots of JS being ran. Most of it belongs to the `polyfills` file. Which is purely `zone.js` in this app. So removing it to see if there are performance improvements. No other change was needed as it's a pretty simple app
