### PR TITLE
perf: avoid layout shifts for swipers

### DIFF
--- a/src/app/projects/images-swiper/images-swiper.component.html
+++ b/src/app/projects/images-swiper/images-swiper.component.html
@@ -1,7 +1,16 @@
 @if (images().length) {
-  <swiper-container [appSwiper]="_effectiveSwiperOptions()" init="false">
+  @let firstImage = images()[0];
+  @let maxSlidesPerView = _maxSlidesPerView();
+  <swiper-container
+    [appSwiper]="_effectiveSwiperOptions()"
+    init="false"
+    [style.aspect-ratio]="
+      maxSlidesPerView
+        ? (maxSlidesPerView * firstImage.width) / firstImage.height
+        : undefined
+    "
+  >
     @for (image of images(); track image; let i = $index) {
-      @let maxSlidesPerView = _maxSlidesPerView();
       <swiper-slide
         [style.aspect-ratio]="image.width / image.height"
         [style.min-width.%]="

--- a/src/app/projects/images-swiper/images-swiper.component.scss
+++ b/src/app/projects/images-swiper/images-swiper.component.scss
@@ -19,18 +19,13 @@
 
   $balanced-luminance-color: theme.$accent;
 
-  swiper-container::part(button-prev) {
-    color: $balanced-luminance-color;
-  }
-
+  swiper-container::part(button-prev),
   swiper-container::part(button-next) {
+    position: absolute; // perf trick 2 avoid layout shifts
     color: $balanced-luminance-color;
   }
 
-  swiper-container::part(bullet-active) {
-    background-color: $balanced-luminance-color;
-  }
-
+  swiper-container::part(bullet-active),
   swiper-container::part(bullet) {
     background-color: $balanced-luminance-color;
   }


### PR DESCRIPTION
A performance issue that comes around often is due to layout shifts. In the meantime the swiper gets loaded, the size of it in screen doesn't match its final size.

After some investigation, turns out that if positioning buttons as absolute and specifying aspect ratio of the slider, the layout can be ready before the swiper loads
