### PR TITLE
fix: preconnect to image CDN

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,8 +1,10 @@
-import { Component } from '@angular/core'
+import { afterNextRender, Component, inject } from '@angular/core'
 import { ENTER_LEAVE_FADE_IN_OUT_ANIMATIONS } from './common/style/animations'
 import { RouterOutlet } from '@angular/router'
 import { LogoComponent } from './logo/logo.component'
 import { HeaderComponent } from './header/header.component'
+import { DOCUMENT } from '@angular/common'
+import { BASE_URL as IMAGE_CDN_BASE_URL } from '../app/common/images/cdn'
 
 @Component({
   selector: 'app-root',
@@ -15,4 +17,21 @@ import { HeaderComponent } from './header/header.component'
   standalone: true,
   imports: [HeaderComponent, LogoComponent, RouterOutlet],
 })
-export class AppComponent {}
+export class AppComponent {
+  private _doc = inject(DOCUMENT)
+
+  constructor() {
+    // Just needed for SSG/R
+    afterNextRender(() => {
+      appendLinkRelPreconnect(this._doc, IMAGE_CDN_BASE_URL)
+    })
+  }
+}
+
+const appendLinkRelPreconnect = (doc: Document, url: string): void => {
+  const linkEl = doc.createElement('link')
+  linkEl.setAttribute('rel', 'preconnect')
+  linkEl.setAttribute('href', url)
+  // 👇 Adding as first node so it preconnects as early as possible
+  doc.head.insertBefore(linkEl, doc.head.children[0])
+}

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,6 @@
     <meta charset="utf-8" />
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="preconnect" href="https://ik.imagekit.io" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" sizes="48x48" />
     <link rel="icon" href="/favicon.svg" sizes="any" type="image/svg+xml" />
     <link rel="apple-touch-icon" href="/images/favicons/apple-touch-icon.png" />


### PR DESCRIPTION
Currently `link rel="preconnect"` is hardcoded to Imagekit. Which isn't anymore the image CDN. Changing it here to be dynamic depending on the image CDN chosen.
