### PR TITLE
refactor: move breakpoints generation as part of image CDN API

### DIFF
--- a/scripts/src/images/breakpoints-from-sizes-and-image.ts
+++ b/scripts/src/images/breakpoints-from-sizes-and-image.ts
@@ -1,47 +1,11 @@
 import { SourceSizeList } from '../models/source-size-list'
-import {
-  Image,
-  ResponsiveImage,
-  ResponsiveImageBreakpoints,
-} from '@/app/common/images/image'
+import { Image, ResponsiveImageBreakpoints } from '@/app/common/images/image'
 import { SourceSize } from '../models/source-size'
 import { MAX_LIMIT, MIN_LIMIT } from '../models/css-media-condition'
-import { DEFAULT_RESOLUTIONS } from '@unpic/core/base'
 import { CSS_PX_UNIT, CSS_VW_UNIT } from '../models/css-length'
-import { Log } from '../utils/log'
+import { DEFAULT_RESOLUTIONS } from '@unpic/core/base'
 
-export const responsiveImageFromSizes = (
-  image: Image,
-  sizes: SourceSizeList,
-  opts: {
-    withoutSizes?: boolean
-  } = {},
-): ResponsiveImage => {
-  const responsiveImageWithoutSizes = {
-    ...image,
-    breakpoints: breakpointsFromSizesAndImage(sizes, image),
-  }
-  if (
-    responsiveImageWithoutSizes.breakpoints.length > MAX_RECOMMENDED_BREAKPOINTS
-  ) {
-    Log.warn(
-      `Too many breakpoints generated for image "%s": %d`,
-      image.src,
-      responsiveImageWithoutSizes.breakpoints.length,
-    )
-  }
-  if (opts.withoutSizes) {
-    return responsiveImageWithoutSizes
-  }
-  return {
-    ...responsiveImageWithoutSizes,
-    sizes: sizes.toString(),
-  }
-}
-
-const MAX_RECOMMENDED_BREAKPOINTS = 20
-
-const breakpointsFromSizesAndImage = (
+export const breakpointsFromSizesAndImage = (
   sourceSizeList: SourceSizeList,
   image: Image,
 ): ResponsiveImageBreakpoints =>

--- a/scripts/src/images/cdn/apis/cloudinary.ts
+++ b/scripts/src/images/cdn/apis/cloudinary.ts
@@ -5,8 +5,9 @@ import { Log } from '../../../utils/log'
 import { CLOUD_NAME } from '@/app/common/images/cdn/cloudinary'
 import { Image } from '@/app/common/images/image'
 
-export class Cloudinary implements ImageCdnApi {
+export class Cloudinary extends ImageCdnApi {
   constructor(sdkOptions: ConfigOptions) {
+    super()
     cloudinary.config(sdkOptions)
   }
 
@@ -43,18 +44,8 @@ export class Cloudinary implements ImageCdnApi {
         src: public_id,
         width,
         height,
-        //version,
-        //asset_id,
       }))
     Log.info('Found %d images in path "%s"', images.length, path)
     return images
   }
 }
-
-//type Unpacked<T> = T extends (infer U)[] ? U : T
-//type ResourceApiResponseItem = Unpacked<ResourceApiResponse['resources']>
-//type CloudinaryImageAsset = ImageAsset
-//& Pick<ResourceApiResponseItem, 'version'> & {
-// TODO: could be included, as it's in the actual response, but not in the response type
-//asset_id: string
-//}

--- a/scripts/src/images/cdn/apis/imagekit.ts
+++ b/scripts/src/images/cdn/apis/imagekit.ts
@@ -12,10 +12,11 @@ import { ImageCdnApi, UNPUBLISHED_TAG } from '../image-cdn-api'
 import { URLSearchParams } from 'url'
 import { URL } from '@/app/common/images/cdn/imagekit'
 
-export class Imagekit implements ImageCdnApi {
+export class Imagekit extends ImageCdnApi {
   private readonly _sdk: ImagekitSdk
 
   constructor(sdkOptions: ImageKitOptions) {
+    super()
     this._sdk = new ImageKit(sdkOptions)
   }
 

--- a/scripts/src/images/cdn/image-cdn-api.ts
+++ b/scripts/src/images/cdn/image-cdn-api.ts
@@ -1,10 +1,56 @@
-import { Image } from '@/app/common/images/image'
+import {
+  Image,
+  ResponsiveImage,
+  ResponsiveImageBreakpoints,
+} from '@/app/common/images/image'
+import { SourceSizeList } from '../../models/source-size-list'
+import { breakpointsFromSizesAndImage } from '../breakpoints-from-sizes-and-image'
+import { Log } from '../../utils/log'
 
-export interface ImageCdnApi {
-  getAllImagesInPath(
+export abstract class ImageCdnApi {
+  abstract getAllImagesInPath(
     path: string,
     includeSubdirectories?: boolean,
   ): Promise<readonly Image[]>
+
+  async responsiveImage(
+    image: Image,
+    sourceSizeList: SourceSizeList,
+    opts: Partial<{
+      withoutSizes: boolean
+    }> = {},
+  ): Promise<ResponsiveImage> {
+    const responsiveImageWithoutSizes = {
+      ...image,
+      breakpoints: await this._breakpointsForImage(image, sourceSizeList),
+    }
+    if (
+      responsiveImageWithoutSizes.breakpoints.length >
+      MAX_RECOMMENDED_BREAKPOINTS
+    ) {
+      Log.warn(
+        `Too many breakpoints generated for image "%s": %d`,
+        image.src,
+        responsiveImageWithoutSizes.breakpoints.length,
+      )
+    }
+    if (opts.withoutSizes) {
+      return responsiveImageWithoutSizes
+    }
+    return {
+      ...responsiveImageWithoutSizes,
+      sizes: sourceSizeList.toString(),
+    }
+  }
+
+  protected async _breakpointsForImage(
+    image: Image,
+    sourceSizeList: SourceSizeList,
+  ): Promise<ResponsiveImageBreakpoints> {
+    return breakpointsFromSizesAndImage(sourceSizeList, image)
+  }
 }
 
 export const UNPUBLISHED_TAG = 'unpublished'
+
+const MAX_RECOMMENDED_BREAKPOINTS = 20

--- a/scripts/src/misc-images.ts
+++ b/scripts/src/misc-images.ts
@@ -7,7 +7,6 @@ import { join } from 'path'
 import { mkdir } from 'fs/promises'
 import { getImageCdnApi } from './images/cdn'
 import { ABOUT, LOGO } from './images/sizes'
-import { responsiveImageFromSizes } from './images/responsive-image-from-sizes'
 
 export const miscImages = async (): Promise<void> => {
   const imageCdnApi = getImageCdnApi()
@@ -24,8 +23,8 @@ export const miscImages = async (): Promise<void> => {
     },
   )
   const miscImages: MiscImages = {
-    horizontalLogo: responsiveImageFromSizes(horizontalLogo, LOGO),
-    aboutPortrait: responsiveImageFromSizes(aboutPortrait, ABOUT),
+    horizontalLogo: await imageCdnApi.responsiveImage(horizontalLogo, LOGO),
+    aboutPortrait: await imageCdnApi.responsiveImage(aboutPortrait, ABOUT),
   }
   await writeJson(
     join(GENERATED_DATA_PATH, appendJsonExtension('misc-images')),

--- a/scripts/src/utils/resolve-sequentially.ts
+++ b/scripts/src/utils/resolve-sequentially.ts
@@ -1,0 +1,9 @@
+export const resolveSequentially = async <T>(
+  promises: readonly Promise<T>[],
+): Promise<readonly T[]> => {
+  const resolved: T[] = []
+  for (const promise of promises) {
+    resolved.push(await promise)
+  }
+  return resolved
+}


### PR DESCRIPTION
To make it easier to integrate Cloudinary responsive generation API, moving first here the function that generates responsive images to the ImageCdnApi. Which by default will use the existing local algorithm based on device resolutions. But that can be easily replaced in any of the implementations. In the Cloudinary one, will use their API to generate breakpoints based on a performance budget.

Introducing also `resolveSequentially` to help resolving sequentially an array of promises. So it's easier to use `map` with functions that return promises and `Promise.all` can't be used in there (in our scenarios due to avoid rate-limit)
