### PR TITLE
test: enable back lighthouse responsive images audit

### DIFF
--- a/lighthouserc.cjs
+++ b/lighthouserc.cjs
@@ -13,23 +13,34 @@ module.exports = {
       ],
     },
     assert: {
-      preset: 'lighthouse:no-pwa',
-      assertions: {
-        //👇 Didn't appear til main bundle was >500kb. Then, Lighthouse wants source maps
-        // If we optimize, we can probably turn this back on. 500kb for main bundle is a bit too much
-        // ~Now we're below 500kb, enabling it again by leaving it commented in case it's bigger~
-        'valid-source-maps': 'off',
-        // 👇 Probably Swiper.js 😭
-        // Just happens on project detail page tho, when many swipers there
-        // Maybe a grid would solve it
-        'non-composited-animations': 'warn',
-        //👇 WIP
-        //   They're not so bad, but can be improved. Disabling til solution is shipped.
-        'uses-responsive-images': 'warn',
-        'bf-cache': 'warn',
-        'csp-xss': 'warn',
-        'unused-javascript': 'warn',
-      },
+      assertMatrix: [
+        // All pages
+        {
+          matchingUrlPattern: '.*',
+          preset: 'lighthouse:no-pwa',
+          assertions: {
+            //👇 Didn't appear til main bundle was >500kb. Then, Lighthouse wants source maps
+            // If we optimize, we can probably turn this back on. 500kb for main bundle is a bit too much
+            // ~Now we're below 500kb, enabling it again by leaving it commented in case it's bigger~
+            'valid-source-maps': 'off',
+            'uses-responsive-images': ['error', { maxLength: 2 }],
+            // 👇 Probably Swiper.js 😭
+            // Just happens on project detail page tho, when many swipers there
+            // Maybe a grid would solve it
+            'non-composited-animations': 'warn',
+            'bf-cache': 'warn',
+            'csp-xss': 'warn',
+            'unused-javascript': 'warn',
+          },
+        },
+        // Project detail
+        {
+          matchingUrlPattern: '.+\/projects\/.+',
+          assertions: {
+            'uses-responsive-images': ['error', { maxLength: 4 }],
+          },
+        },
+      ],
     },
   },
 }

--- a/lighthouserc.cjs
+++ b/lighthouserc.cjs
@@ -23,7 +23,7 @@ module.exports = {
             // If we optimize, we can probably turn this back on. 500kb for main bundle is a bit too much
             // ~Now we're below 500kb, enabling it again by leaving it commented in case it's bigger~
             'valid-source-maps': 'off',
-            'uses-responsive-images': ['error', { maxLength: 2 }],
+            'uses-responsive-images': 'off', // It is customized below
             // 👇 Probably Swiper.js 😭
             // Just happens on project detail page tho, when many swipers there
             // Maybe a grid would solve it
@@ -31,6 +31,13 @@ module.exports = {
             'bf-cache': 'warn',
             'csp-xss': 'warn',
             'unused-javascript': 'warn',
+          },
+        },
+        // Non-project detail
+        {
+          matchingUrlPattern: '^((?!\\/projects\\/.+).)*$',
+          assertions: {
+            'uses-responsive-images': ['error', { maxLength: 2 }],
           },
         },
         // Project detail


### PR DESCRIPTION
Now that we've optimized responsive images, it's time to set new limits for the project detail page. It's quite difficult to size all images (there are 79 in chiasma project) properly. So accepting the ones that aren't properly sized as OK and moving on.

These are the Lighthouse results for `/projects/chiasma` page after many iterations on this.

The referred breakpoints algorithms are:
1. **Breakpoint estimation based on sizes (v1)**: based on Lighthouse limit, common resolutions, high density displays, not considering compression and a fixed portrait aspect ratio of 9:16. Lived inside app code, under `common/images`. Plus infra in `common/(css|html)`.
2. **Breakpoint estimation based on sizes (v2) + image**: same as v1, but taking into account actual aspect ratio & a fixed compression rate.
3. **Cloudinary Responsive Breakpoints API: with page padding**. With params `width:200-1920`, `bytes_step:20` and `max_images=20`. Taking into account page padding.
4. **Cloudinary Responsive Breakpoints API: without page padding**. Same params as before. Page padding not taken into account

| | `modern-image-formats` | `uses-responsive-images` |
|--:|:-:|:-:|
| ImageKit + Algorithm 1 | 0 / 0 | 107 KiB / 8 els | 
| Cloudinary + Algorithm 1 | 14.6 KiB / 1 el (`kdpkf` pic) | 94 KiB / 7 els |
| Cloudinary + Algorithm 3 | 0 / 0 | 39 KiB / 2 els (logo is 1 of them) |
| Cloudinary + Algorithm 2 | 0 / 0 | 107 KiB / 8 els |
| Cloudinary + Algorithm 4 | 0 / 0 | 70 KiB / 4 els (logo is 1 of them) |

Current option implemented is last one, "Cloudinary + Algorithm 4". Next steps can be take padding into account to improve performance. Plus just provide different densities for the logo.
