### PR TITLE
perf: add horizontal page padding in responsive image sizes

### DIFF
--- a/lighthouserc.cjs
+++ b/lighthouserc.cjs
@@ -23,7 +23,7 @@ module.exports = {
             // If we optimize, we can probably turn this back on. 500kb for main bundle is a bit too much
             // ~Now we're below 500kb, enabling it again by leaving it commented in case it's bigger~
             'valid-source-maps': 'off',
-            'uses-responsive-images': 'off', // It is customized below
+            'uses-responsive-images': ['error', { maxLength: 2 }],
             // 👇 Probably Swiper.js 😭
             // Just happens on project detail page tho, when many swipers there
             // Maybe a grid would solve it
@@ -36,16 +36,12 @@ module.exports = {
         // Non-project detail
         {
           matchingUrlPattern: '^((?!\\/projects\\/.+).)*$',
-          assertions: {
-            'uses-responsive-images': ['error', { maxLength: 2 }],
-          },
+          assertions: {},
         },
         // Project detail
         {
           matchingUrlPattern: '.+\/projects\/.+',
-          assertions: {
-            'uses-responsive-images': ['error', { maxLength: 4 }],
-          },
+          assertions: {},
         },
       ],
     },

--- a/scripts/src/images/breakpoints-from-sizes-and-image.ts
+++ b/scripts/src/images/breakpoints-from-sizes-and-image.ts
@@ -2,7 +2,7 @@ import { SourceSizeList } from '../models/source-size-list'
 import { Image, ResponsiveImageBreakpoints } from '@/app/common/images/image'
 import { SourceSize } from '../models/source-size'
 import { MAX_LIMIT, MIN_LIMIT } from '../models/css-media-condition'
-import { CSS_PX_UNIT, CSS_VW_UNIT } from '../models/css-length'
+import { CSS_PX_UNIT, CSS_VW_UNIT, CssLength } from '../models/css-length'
 import { DEFAULT_RESOLUTIONS } from '@unpic/core/base'
 
 export const breakpointsFromSizesAndImage = (
@@ -67,7 +67,14 @@ const applicableResolutionWidth = (
 const lengthToPx = (
   length: SourceSize['length'],
   viewportWidth: number,
-): number => {
+): number =>
+  (Array.isArray(length) ? length : [length]).reduce<number>(
+    (accumulator, length) =>
+      accumulator + singleLengthToPx(length, viewportWidth),
+    0,
+  )
+
+const singleLengthToPx = (length: CssLength, viewportWidth: number): number => {
   switch (length.unit) {
     case CSS_PX_UNIT:
       return length.quantity

--- a/scripts/src/images/sizes.ts
+++ b/scripts/src/images/sizes.ts
@@ -1,16 +1,34 @@
 import { SourceSizeList, sourceSizeList } from '../models/source-size-list'
-import { sourceSize } from '../models/source-size'
+import { SourceSize, sourceSize } from '../models/source-size'
 import { Px, Vw } from '../models/css-length'
 import { maxWidth, minWidth } from '../models/css-media-condition'
 import { BREAKPOINT_S_PX, BREAKPOINT_XS_PX } from '@/app/common/breakpoints'
 import { ProjectDetailAlbum } from '@/app/projects/project'
 import { PROJECT_DETAIL_PAGE_SWIPER_FULL } from '@/app/projects/project-detail-page/project-detail-page-swipers'
+import { HORIZONTAL_PAGE_PADDING_PX } from '@/app/common/paddings'
 
-// TODO: add horizontal padding
+const horizontalPagePadding = (divider = 1) =>
+  Px(HORIZONTAL_PAGE_PADDING_PX / divider)
+const withHorizontalPagePadding = (
+  length: SourceSize['length'],
+  divider = 1,
+): SourceSize['length'] => {
+  const padding = horizontalPagePadding(divider)
+  return padding.quantity === 0
+    ? length
+    : Array.isArray(length)
+      ? [...length, padding]
+      : [length, padding]
+}
+const withoutHorizontalPagePadding = (
+  length: SourceSize['length'],
+  divider = 1,
+): SourceSize['length'] => withHorizontalPagePadding(length, divider * -1)
+
 export const ABOUT = sourceSizeList(
-  sourceSize(Vw(35), minWidth(BREAKPOINT_S_PX)),
-  sourceSize(Vw(60), minWidth(BREAKPOINT_XS_PX)),
-  sourceSize(Vw(75)),
+  sourceSize(withoutHorizontalPagePadding(Vw(35)), minWidth(BREAKPOINT_S_PX)),
+  sourceSize(withoutHorizontalPagePadding(Vw(60)), minWidth(BREAKPOINT_XS_PX)),
+  sourceSize(withoutHorizontalPagePadding(Vw(75))),
 )
 
 // TODO: could be just one asset indeed (for max-height + multiple densities)
@@ -22,15 +40,26 @@ export const LOGO = (() => {
     (MAX_HEIGHT_PX * LOGO_ASPECT_RATIO.width) / LOGO_ASPECT_RATIO.height,
   )
   return sourceSizeList(
-    sourceSize(Vw(100), maxWidth(MAX_WIDTH_PX)),
+    sourceSize(
+      withoutHorizontalPagePadding(Vw(100)),
+      maxWidth(MAX_WIDTH_PX + HORIZONTAL_PAGE_PADDING_PX),
+    ),
     sourceSize(Px(MAX_WIDTH_PX)),
   )
 })()
 
-export const PROJECT_LIST_ITEM = sourceSizeList(
-  sourceSize(Vw(33.3), minWidth(BREAKPOINT_S_PX)),
-  sourceSize(Vw(50)),
-)
+export const PROJECT_LIST_ITEM = (() => {
+  const SLIDES_PER_VIEW = 2
+  return sourceSizeList(
+    sourceSize(
+      withoutHorizontalPagePadding(Vw(33.3), SLIDES_PER_VIEW),
+      minWidth(BREAKPOINT_S_PX),
+    ),
+    sourceSize(
+      withoutHorizontalPagePadding(Vw(100 / SLIDES_PER_VIEW), SLIDES_PER_VIEW),
+    ),
+  )
+})()
 
 export const PROJECT_DETAIL_BY_PRESET_SIZE: Record<
   ProjectDetailAlbum['size'],
@@ -41,18 +70,37 @@ export const PROJECT_DETAIL_BY_PRESET_SIZE: Record<
     const SLIDES_PER_VIEW = PROJECT_DETAIL_PAGE_SWIPER_FULL.slidesPerView
     return sourceSizeList(
       sourceSize(
-        Px(FIXED_WIDTH_PX / SLIDES_PER_VIEW),
-        minWidth(FIXED_WIDTH_PX),
+        withoutHorizontalPagePadding(
+          Px(FIXED_WIDTH_PX / SLIDES_PER_VIEW),
+          SLIDES_PER_VIEW,
+        ),
+        minWidth(FIXED_WIDTH_PX + HORIZONTAL_PAGE_PADDING_PX),
       ),
-      sourceSize(Vw(100 / SLIDES_PER_VIEW)),
+      sourceSize(
+        withoutHorizontalPagePadding(
+          Vw(100 / SLIDES_PER_VIEW),
+          SLIDES_PER_VIEW,
+        ),
+      ),
     )
   })(),
   half: (() => {
     const SLIDERS_WIDE_VIEW = 2
     const SLIDERS_NARROW_VIEW = 1
     return sourceSizeList(
-      sourceSize(Vw(100 / SLIDERS_WIDE_VIEW), minWidth(BREAKPOINT_S_PX)),
-      sourceSize(Vw(100 / SLIDERS_NARROW_VIEW)),
+      sourceSize(
+        withoutHorizontalPagePadding(
+          Vw(100 / SLIDERS_WIDE_VIEW),
+          SLIDERS_WIDE_VIEW,
+        ),
+        minWidth(BREAKPOINT_S_PX),
+      ),
+      sourceSize(
+        withoutHorizontalPagePadding(
+          Vw(100 / SLIDERS_NARROW_VIEW),
+          SLIDERS_NARROW_VIEW,
+        ),
+      ),
     )
   })(),
 }

--- a/scripts/src/models/source-size.ts
+++ b/scripts/src/models/source-size.ts
@@ -4,17 +4,36 @@ import { CssPxLimitMediaCondition } from './css-media-condition'
 // https://html.spec.whatwg.org/multipage/images.html#sizes-attribute
 export class SourceSize {
   constructor(
-    readonly length: CssLength, // | 'auto'
+    readonly length: CssLength | readonly CssLength[], // | 'auto'
     readonly mediaCondition?: CssPxLimitMediaCondition,
   ) {}
 
   toString(): string {
+    const lengthString = lengthAsString(this.length)
     if (this.mediaCondition === undefined) {
-      return this.length.toString()
+      return lengthString
     }
-    return [this.mediaCondition, this.length].join(' ')
+    return [this.mediaCondition, lengthString].join(' ')
   }
 }
+
+const lengthAsString = (lengthOrLengths: SourceSize['length']): string => {
+  if (!(Array.isArray as isCssLengthArray)(lengthOrLengths)) {
+    return lengthOrLengths.toString()
+  }
+  const parts = lengthOrLengths
+    .filter((length) => length.quantity !== 0)
+    .map<string>((length, index) =>
+      index === 0
+        ? length.toString()
+        : `${length.quantity > 0 ? '+' : '-'} ${Math.abs(length.quantity)}${length.unit}`,
+    )
+  return `calc(${parts.join(' ')})`
+}
+
+type isCssLengthArray = (
+  lengthOrLengths: SourceSize['length'],
+) => lengthOrLengths is readonly CssLength[]
 
 export const sourceSize = (
   length: SourceSize['length'],

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -17,6 +17,7 @@
     "src/**/*.ts",
     "../src/app/common/breakpoints.ts",
     "../src/app/common/directories.ts",
+    "../src/app/common/paddings.ts",
     "../src/app/common/social.ts",
     "../src/app/common/images/cdn/**/*.ts",
     "../src/app/common/images/image.ts",

--- a/src/app/common/paddings.ts
+++ b/src/app/common/paddings.ts
@@ -1,0 +1,2 @@
+// Keep in sync
+export const HORIZONTAL_PAGE_PADDING_PX = 36


### PR DESCRIPTION
Adds horizontal page padding into the equation of calculating the rendered image size to set the `sizes` attribute of responsive image elements. 

tl;dr: 

| Before | After |
|--:|:--|
| `(max-width: 371px) 100vw, 371px` | `(max-width: 407px) calc(100vw - 36px),371px` |

This should improve score for the `uses-responsive-images` Lighthouse audit.

Comparison after running tests (see previous table with references at #612):

|                                    | `modern-image-formats` | `uses-responsive-images` |
|-----------------------------------:|:-:|:-:|
| Cloudinary + Algorithm 4 (before)  | 0 / 0 | 70 KiB / 4 els (logo is 1 of them) |
| Cloudinary + Algorithm 3 (now, after)  | 0 / 0 | 13 KiB / 1 el (logo) |

Not sure why it differs from same combination in #612 . Maybe the algorithm was not 100% the same or there was some mistake when specifying layouts.

Updating Lighthouse assertion so that it's stricter. Unifying all to 2 max as `/` and `/about` have 2 failing items. In `/` it's a preview image + logo. In `/about` it's the portrait + logo. If solving the logo we can reduce that to 1 only.