### PR TITLE
perf: try writing ugly JSONs to see size reductions

### DIFF
--- a/scripts/src/utils/json.ts
+++ b/scripts/src/utils/json.ts
@@ -34,7 +34,7 @@ export const writeJsonSync = async (
   data: object,
 ): Promise<void> => writeFileSync(path, stringifyJson(data))
 
-const stringifyJson = (json: object): string => JSON.stringify(json, null, 2)
+const stringifyJson = (json: object): string => JSON.stringify(json)
 
 export const listJsonFilesInDirectory = async (
   path: string,


### PR DESCRIPTION
Let's see if JSONs can be transferred faster due to reducing their network transfer size

**Before**
![image](https://github.com/user-attachments/assets/2aa1ff5d-ac9e-4681-95d8-7df5841aeeac)

**After**
![image](https://github.com/user-attachments/assets/9483a9c2-cded-496e-b8ae-6e41eb573c5d)

There's a 2x-3x difference in uncompressed size. However transfer size barely grows 0.5-0.6KiB when using brotli. 

Almost the same if using `gzip`

**Before**
![image](https://github.com/user-attachments/assets/6b31a820-6a8c-42c8-8283-7b7295ef06c1)

**After**
![image](https://github.com/user-attachments/assets/116a46f3-9f7c-4d91-a439-4c18b4c8c40a)

Not worth it then! It's nice to have access to them quickly when developing
