### PR TITLE
refactor: split breakpoints generation from CDN API

### DIFF
--- a/scripts/src/images/breakpoints-from-sizes-and-image.ts
+++ b/scripts/src/images/breakpoints-from-sizes-and-image.ts
@@ -6,8 +6,8 @@ import { CSS_PX_UNIT, CSS_VW_UNIT, CssLength } from '../models/css-length'
 import { DEFAULT_RESOLUTIONS } from '@unpic/core/base'
 
 export const breakpointsFromSizesAndImage = (
-  sourceSizeList: SourceSizeList,
   image: Image,
+  sourceSizeList: SourceSizeList,
 ): ResponsiveImageBreakpoints =>
   reduceBreakpoints(
     uniq(

--- a/scripts/src/images/cdn/apis/imagekit.ts
+++ b/scripts/src/images/cdn/apis/imagekit.ts
@@ -20,7 +20,7 @@ export class Imagekit extends ImageCdnApi {
     this._sdk = new ImageKit(sdkOptions)
   }
 
-  static fromEnv(): Imagekit {
+  static getInstance(): Imagekit {
     dotenv.config()
 
     const { IMAGEKIT_PUBLIC_KEY, IMAGEKIT_PRIVATE_KEY } = process.env

--- a/scripts/src/images/cdn/image-cdn-api.ts
+++ b/scripts/src/images/cdn/image-cdn-api.ts
@@ -1,56 +1,10 @@
-import {
-  Image,
-  ResponsiveImage,
-  ResponsiveImageBreakpoints,
-} from '@/app/common/images/image'
-import { SourceSizeList } from '../../models/source-size-list'
-import { breakpointsFromSizesAndImage } from '../breakpoints-from-sizes-and-image'
-import { Log } from '../../utils/log'
+import { Image } from '@/app/common/images/image'
 
 export abstract class ImageCdnApi {
   abstract getAllImagesInPath(
     path: string,
     includeSubdirectories?: boolean,
   ): Promise<readonly Image[]>
-
-  async responsiveImage(
-    image: Image,
-    sourceSizeList: SourceSizeList,
-    opts: Partial<{
-      withoutSizes: boolean
-    }> = {},
-  ): Promise<ResponsiveImage> {
-    const responsiveImageWithoutSizes = {
-      ...image,
-      breakpoints: await this._breakpointsForImage(image, sourceSizeList),
-    }
-    if (
-      responsiveImageWithoutSizes.breakpoints.length >
-      MAX_RECOMMENDED_BREAKPOINTS
-    ) {
-      Log.warn(
-        `Too many breakpoints generated for image "%s": %d`,
-        image.src,
-        responsiveImageWithoutSizes.breakpoints.length,
-      )
-    }
-    if (opts.withoutSizes) {
-      return responsiveImageWithoutSizes
-    }
-    return {
-      ...responsiveImageWithoutSizes,
-      sizes: sourceSizeList.toString(),
-    }
-  }
-
-  protected async _breakpointsForImage(
-    image: Image,
-    sourceSizeList: SourceSizeList,
-  ): Promise<ResponsiveImageBreakpoints> {
-    return breakpointsFromSizesAndImage(sourceSizeList, image)
-  }
 }
 
 export const UNPUBLISHED_TAG = 'unpublished'
-
-const MAX_RECOMMENDED_BREAKPOINTS = 20

--- a/scripts/src/images/cdn/index.ts
+++ b/scripts/src/images/cdn/index.ts
@@ -8,8 +8,8 @@ import { Log } from '../../utils/log'
 import type { ImageCdnApi } from './image-cdn-api'
 
 const CDN_APIS_BY_NAME: Record<CdnNames, () => Promise<ImageCdnApi>> = {
-  imagekit: async () => Imagekit.fromEnv(),
-  cloudinary: Cloudinary.fromEnv,
+  imagekit: async () => Imagekit.getInstance(),
+  cloudinary: Cloudinary.getInstance,
 }
 export const getImageCdnApi = (): Promise<ImageCdnApi> => {
   Log.info(`Using ${CDN_NAME} as image CDN`)

--- a/scripts/src/images/responsive/breakpoints.ts
+++ b/scripts/src/images/responsive/breakpoints.ts
@@ -1,0 +1,28 @@
+import { Image, ResponsiveImageBreakpoints } from '@/app/common/images/image'
+import { SourceSizeList } from '../../models/source-size-list'
+import { CDN_NAME } from '@/app/common/images/cdn'
+import { CDN_NAME as CLOUDINARY_CDN_NAME } from '@/app/common/images/cdn/cloudinary'
+import { Cloudinary } from '../cdn/apis/cloudinary'
+import { breakpointsFromSizesAndImage } from '../breakpoints-from-sizes-and-image'
+
+export type BreakpointsFn = (
+  image: Image,
+  sourceSizeList: SourceSizeList,
+) => Promise<ResponsiveImageBreakpoints>
+
+export const getBreakpointsFn = async (): Promise<BreakpointsFn> => {
+  if (CDN_NAME === CLOUDINARY_CDN_NAME) {
+    return getCloudinaryResponsiveBreakpointsApi()
+  }
+  return getBreakpointsFromSizesAndImageApi()
+}
+
+const getCloudinaryResponsiveBreakpointsApi =
+  async (): Promise<BreakpointsFn> => {
+    const cloudinaryApi = await Cloudinary.getInstance()
+    return cloudinaryApi.breakpointsForImage.bind(cloudinaryApi)
+  }
+
+const getBreakpointsFromSizesAndImageApi =
+  async (): Promise<BreakpointsFn> => async (image, sourceSizeList) =>
+    breakpointsFromSizesAndImage(image, sourceSizeList)

--- a/scripts/src/images/responsive/to-responsive-image.ts
+++ b/scripts/src/images/responsive/to-responsive-image.ts
@@ -1,0 +1,48 @@
+import { Image, ResponsiveImage } from '@/app/common/images/image'
+import { SourceSizeList } from '../../models/source-size-list'
+import { Log } from '../../utils/log'
+import { getBreakpointsFn } from './breakpoints'
+import { resolveSequentially } from '../../utils/resolve-sequentially'
+
+export const toResponsiveImage = async (
+  image: Image,
+  sourceSizeList: SourceSizeList,
+  opts: Partial<{
+    withoutSizes: boolean
+  }> = {},
+): Promise<ResponsiveImage> => {
+  const breakpointsFunction = await getBreakpointsFn()
+  const responsiveImageWithoutSizes = {
+    ...image,
+    breakpoints: await breakpointsFunction(image, sourceSizeList),
+  }
+  if (
+    responsiveImageWithoutSizes.breakpoints.length > MAX_RECOMMENDED_BREAKPOINTS
+  ) {
+    Log.warn(
+      `Too many breakpoints generated for image "%s": %d`,
+      image.src,
+      responsiveImageWithoutSizes.breakpoints.length,
+    )
+  }
+  if (opts.withoutSizes) {
+    return responsiveImageWithoutSizes
+  }
+  return {
+    ...responsiveImageWithoutSizes,
+    sizes: sourceSizeList.toString(),
+  }
+}
+
+export const toResponsiveImages = async (
+  images: readonly Image[],
+  sourceSizeList: SourceSizeList,
+): Promise<readonly ResponsiveImage[]> => {
+  return resolveSequentially(
+    images.map((image) =>
+      toResponsiveImage(image, sourceSizeList, { withoutSizes: true }),
+    ),
+  )
+}
+
+const MAX_RECOMMENDED_BREAKPOINTS = 20

--- a/scripts/src/misc-images.ts
+++ b/scripts/src/misc-images.ts
@@ -7,6 +7,7 @@ import { join } from 'path'
 import { mkdir } from 'fs/promises'
 import { getImageCdnApi } from './images/cdn'
 import { ABOUT, LOGO } from './images/sizes'
+import { toResponsiveImage } from './images/responsive/to-responsive-image'
 
 export const miscImages = async (): Promise<void> => {
   const imageCdnApi = await getImageCdnApi()
@@ -23,8 +24,8 @@ export const miscImages = async (): Promise<void> => {
     },
   )
   const miscImages: MiscImages = {
-    horizontalLogo: await imageCdnApi.responsiveImage(horizontalLogo, LOGO),
-    aboutPortrait: await imageCdnApi.responsiveImage(aboutPortrait, ABOUT),
+    horizontalLogo: await toResponsiveImage(horizontalLogo, LOGO),
+    aboutPortrait: await toResponsiveImage(aboutPortrait, ABOUT),
   }
   await writeJson(
     join(GENERATED_DATA_PATH, appendJsonExtension('misc-images')),

--- a/scripts/src/projects-content.ts
+++ b/scripts/src/projects-content.ts
@@ -33,6 +33,7 @@ import {
   PROJECT_LIST_ITEM,
 } from './images/sizes'
 import { resolveSequentially } from './utils/resolve-sequentially'
+import { toResponsiveImages } from './images/responsive/to-responsive-image'
 
 export const projectsContent = async () => {
   const expandedCmsProjects = await expandCmsProjects()
@@ -60,16 +61,11 @@ const expandCmsProject = async (
 ): Promise<ExpandedCmsProject> => {
   Log.info('Expanding project "%s"', cmsProject.slug)
   const projectImageDirectory = `${PROJECTS_DIR}/${cmsProject.slug}`
-  const previewImages = await resolveSequentially(
-    (
-      await imageCdnApi.getAllImagesInPath(
-        `${projectImageDirectory}/${PREVIEW_PRESET_JSON.slug}`,
-      )
-    ).map((image) =>
-      imageCdnApi.responsiveImage(image, PROJECT_LIST_ITEM, {
-        withoutSizes: true,
-      }),
+  const previewImages = await toResponsiveImages(
+    await imageCdnApi.getAllImagesInPath(
+      `${projectImageDirectory}/${PREVIEW_PRESET_JSON.slug}`,
     ),
+    PROJECT_LIST_ITEM,
   )
   if (!previewImages.length) {
     throw new Error(`Project ${cmsProject.slug} has no preview images`)
@@ -107,13 +103,7 @@ const expandCmsProject = async (
         return {
           title,
           imageSizes: sourceSizeList.toString(),
-          images: await resolveSequentially(
-            images.map((image) =>
-              imageCdnApi.responsiveImage(image, sourceSizeList, {
-                withoutSizes: true,
-              }),
-            ),
-          ),
+          images: await toResponsiveImages(images, sourceSizeList),
           size: preset.size,
         }
       },


### PR DESCRIPTION
After working a bit to sign image URLs, seems that process of fetching an image reference is getting a bit cumbersome:

1. Look it in the CDN via the CDN API
2. Generate breakpoints and transform it into a responsive image
3. Provide signature for all breakpoints (this will come soon)

Combine this with lists of images where `map` + `Promise.all`/`resolveSequentially` is used and gets quite messy. Would be nice to have some utils to help in these.

Also, don't feel that the breakpoints generation should be tied to the image CDN. The fact Cloudinary provides an API for that is more the exception than the norm.

So to simplify + decouple breakpoints generation from image CDN, refactoring a bit:
 - Responsive breakpoints generation split into a separate files / functions. Provide a helper to automatically decide which to choose depending if images are on Cloudinary or not.
 - Add util to map a list of images into responsive images, where breakpoints will be generated by the automatically determined function.

Now, signatures can be added as an extra step. But following the same pattern it will be simpler:
 - Image CDN API provides API to sign one
 - Util to sign more than one at the time

Finally, some extra refactors:
- `Api.fromEnv` to `Api.getInstance` given it's doing more than initializing from env
