### PR TITLE
feat: sign images to avoid unauthorized transforms

### DIFF
--- a/scripts/src/images/breakpoints-from-sizes-and-image.ts
+++ b/scripts/src/images/breakpoints-from-sizes-and-image.ts
@@ -1,5 +1,5 @@
 import { SourceSizeList } from '../models/source-size-list'
-import { Image, ResponsiveImageBreakpoints } from '@/app/common/images/image'
+import { Breakpoints, Image } from '@/app/common/images/image'
 import { SourceSize } from '../models/source-size'
 import { MAX_LIMIT, MIN_LIMIT } from '../models/css-media-condition'
 import { CSS_PX_UNIT, CSS_VW_UNIT, CssLength } from '../models/css-length'
@@ -8,7 +8,7 @@ import { DEFAULT_RESOLUTIONS } from '@unpic/core/base'
 export const breakpointsFromSizesAndImage = (
   image: Image,
   sourceSizeList: SourceSizeList,
-): ResponsiveImageBreakpoints =>
+): Breakpoints =>
   reduceBreakpoints(
     uniq(
       sourceSizeList.sizes.reduce<BreakpointsAndResolutionWidths>(
@@ -47,8 +47,8 @@ export const breakpointsFromSizesAndImage = (
   )
 
 interface BreakpointsAndResolutionWidths {
-  breakpoints: ResponsiveImageBreakpoints
-  resolutionWidths: ResponsiveImageBreakpoints
+  breakpoints: readonly number[]
+  resolutionWidths: readonly number[]
 }
 
 const applicableResolutionWidth = (

--- a/scripts/src/images/cdn/apis/cloudinary.ts
+++ b/scripts/src/images/cdn/apis/cloudinary.ts
@@ -2,8 +2,11 @@ import { ImageCdnApi, UNPUBLISHED_TAG } from '../image-cdn-api'
 import { ConfigOptions, v2 as cloudinary } from 'cloudinary'
 import dotenv from 'dotenv'
 import { Log } from '../../../utils/log'
-import { CLOUD_NAME } from '@/app/common/images/cdn/cloudinary'
-import { Image, ResponsiveImageBreakpoints } from '@/app/common/images/image'
+import {
+  ANTE_TRANSFORMATIONS,
+  CLOUD_NAME,
+} from '@/app/common/images/cdn/cloudinary'
+import { Breakpoints, Image } from '@/app/common/images/image'
 import { SCRIPTS_CACHE_PATH } from '../../../utils/paths'
 import { mkdir } from 'fs/promises'
 import {
@@ -79,7 +82,7 @@ export class Cloudinary extends ImageCdnApi {
     return images
   }
 
-  async breakpointsForImage(image: Image): Promise<ResponsiveImageBreakpoints> {
+  async breakpointsForImage(image: Image): Promise<Breakpoints> {
     const cachedBreakpoints = breakpointsCache.get(image.src)
     if (cachedBreakpoints) {
       return cachedBreakpoints
@@ -113,11 +116,42 @@ export class Cloudinary extends ImageCdnApi {
     breakpointsCache.set(image.src, sortedAndFullWidthBreakpoints)
     return sortedAndFullWidthBreakpoints
   }
+
+  async signImageBreakpoint(image: Image, breakpoint: number): Promise<string> {
+    // Seems there's no way to get the raw sig using Cloudinary's Node.js SDK
+    // https://github.com/cloudinary/cloudinary_npm/blob/2.6.0/lib/utils/index.js#L894-L898
+    // So extracting it from the URL instead to avoid signing manually
+    const imageUrl = cloudinary.url(image.src, {
+      urlAnalytics: false,
+      sign_url: true,
+      raw_transformation: [...ANTE_TRANSFORMATIONS, `w_${breakpoint}`].join(
+        ',',
+      ),
+    })
+    const paths = new URL(imageUrl).pathname.substring(1).split('/')
+    if (!(paths.length > SIGNATURE_INDEX_IN_PATH)) {
+      throw new Error(`Cannot find signature in image URL "${imageUrl}"`)
+    }
+    const signature = paths[3]
+    if (
+      !signature.startsWith(SIGNATURE_PREFIX) ||
+      !signature.endsWith(SIGNATURE_SUFFIX)
+    ) {
+      throw new Error(
+        `Signature does not have an expected format: "${signature}"`,
+      )
+    }
+    return signature
+  }
 }
 
 const VERSION_SEGMENT_PREFIX = 'v'
 
-let breakpointsCache: Map<string, ResponsiveImageBreakpoints>
+const SIGNATURE_INDEX_IN_PATH = 3
+const SIGNATURE_PREFIX = 's--'
+const SIGNATURE_SUFFIX = '--'
+
+let breakpointsCache: Map<string, Breakpoints>
 const BREAKPOINTS_CACHE_FILEPATH = join(
   SCRIPTS_CACHE_PATH,
   appendJsonExtension('breakpoints'),

--- a/scripts/src/images/cdn/apis/cloudinary.ts
+++ b/scripts/src/images/cdn/apis/cloudinary.ts
@@ -5,6 +5,7 @@ import { Log } from '../../../utils/log'
 import {
   ANTE_TRANSFORMATIONS,
   CLOUD_NAME,
+  IMAGE_DELIVERY_TYPE,
 } from '@/app/common/images/cdn/cloudinary'
 import { Breakpoints, Image } from '@/app/common/images/image'
 import { SCRIPTS_CACHE_PATH } from '../../../utils/paths'
@@ -124,6 +125,7 @@ export class Cloudinary extends ImageCdnApi {
     const imageUrl = cloudinary.url(image.src, {
       urlAnalytics: false,
       sign_url: true,
+      type: IMAGE_DELIVERY_TYPE,
       raw_transformation: [...ANTE_TRANSFORMATIONS, `w_${breakpoint}`].join(
         ',',
       ),

--- a/scripts/src/images/cdn/apis/cloudinary.ts
+++ b/scripts/src/images/cdn/apis/cloudinary.ts
@@ -3,8 +3,8 @@ import { ConfigOptions, v2 as cloudinary } from 'cloudinary'
 import dotenv from 'dotenv'
 import { Log } from '../../../utils/log'
 import {
-  ANTE_TRANSFORMATIONS,
   CLOUD_NAME,
+  getRawTransformationForBreakpoint,
   IMAGE_DELIVERY_TYPE,
 } from '@/app/common/images/cdn/cloudinary'
 import { Breakpoints, Image, ResponsiveImage } from '@/app/common/images/image'
@@ -16,7 +16,6 @@ import {
   writeJsonSync,
 } from '../../../utils/json'
 import { join } from 'path'
-import { isDefined } from '@/app/common/is-defined'
 
 export class Cloudinary implements ImageCdnApi {
   private static _sdkOptions: ConfigOptions
@@ -123,12 +122,7 @@ export class Cloudinary implements ImageCdnApi {
       urlAnalytics: false,
       sign_url: true,
       type: IMAGE_DELIVERY_TYPE,
-      raw_transformation: [
-        ...ANTE_TRANSFORMATIONS,
-        breakpoint ? `w_${breakpoint}` : undefined,
-      ]
-        .filter(isDefined)
-        .join(','),
+      raw_transformation: getRawTransformationForBreakpoint(breakpoint),
     })
     const paths = new URL(imageUrl).pathname.substring(1).split('/')
     if (!(paths.length > SIGNATURE_INDEX_IN_PATH)) {

--- a/scripts/src/images/cdn/apis/imagekit.ts
+++ b/scripts/src/images/cdn/apis/imagekit.ts
@@ -10,7 +10,7 @@ import {
 import { Image } from '@/app/common/images/image'
 import { ImageCdnApi, UNPUBLISHED_TAG } from '../image-cdn-api'
 import { URLSearchParams } from 'url'
-import { URL as IMAGEKIT_URL } from '@/app/common/images/cdn/imagekit'
+import { CLOUD_URL as IMAGEKIT_URL } from '@/app/common/images/cdn/imagekit'
 import { getSignature } from 'imagekit/dist/libs/url/builder'
 
 export class Imagekit extends ImageCdnApi {

--- a/scripts/src/images/cdn/apis/imagekit.ts
+++ b/scripts/src/images/cdn/apis/imagekit.ts
@@ -12,12 +12,12 @@ import { ImageCdnApi, UNPUBLISHED_TAG } from '../image-cdn-api'
 import { URLSearchParams } from 'url'
 import { CLOUD_URL as IMAGEKIT_URL } from '@/app/common/images/cdn/imagekit'
 import { getSignature } from 'imagekit/dist/libs/url/builder'
+import { isDefined } from '@/app/common/is-defined'
 
-export class Imagekit extends ImageCdnApi {
+export class Imagekit implements ImageCdnApi {
   private readonly _sdk: ImagekitSdk
 
   constructor(sdkOptions: ImageKitOptions) {
-    super()
     this._sdk = new ImageKit(sdkOptions)
   }
 
@@ -76,15 +76,20 @@ export class Imagekit extends ImageCdnApi {
     }
   }
 
-  async signImageBreakpoint(image: Image, breakpoint: number): Promise<string> {
-    const transformationsString = `tr:w-${breakpoint}`
+  async signImage(
+    image: Image,
+    breakpoint: number | undefined,
+  ): Promise<string> {
+    const transformationsString = breakpoint ? `tr:w-${breakpoint}` : undefined
     const { privateKey, urlEndpoint } = this._sdk.options
     // https://github.com/angular/angular/blob/19.2.5/packages/common/src/directives/ng_optimized_image/image_loaders/imagekit_loader.ts
     const url = [
       urlEndpoint,
       transformationsString,
       image.src.startsWith('/') ? image.src.substring(1) : image.src,
-    ].join('/')
+    ]
+      .filter(isDefined)
+      .join('/')
     // https://github.com/imagekit-developer/imagekit-nodejs/blob/6.0.0/libs/url/builder.ts#L169
     return getSignature({
       privateKey,

--- a/scripts/src/images/cdn/apis/imagekit.ts
+++ b/scripts/src/images/cdn/apis/imagekit.ts
@@ -10,9 +10,8 @@ import {
 import { Image } from '@/app/common/images/image'
 import { ImageCdnApi, UNPUBLISHED_TAG } from '../image-cdn-api'
 import { URLSearchParams } from 'url'
-import { CLOUD_URL } from '@/app/common/images/cdn/imagekit'
+import { CLOUD_URL, urlForBreakpoint } from '@/app/common/images/cdn/imagekit'
 import { getSignature } from 'imagekit/dist/libs/url/builder'
-import { isDefined } from '@/app/common/is-defined'
 
 export class Imagekit implements ImageCdnApi {
   private readonly _sdk: ImagekitSdk
@@ -79,17 +78,9 @@ export class Imagekit implements ImageCdnApi {
     image: Image,
     breakpoint: number | undefined,
   ): Promise<string> {
-    const transformationsString = breakpoint ? `tr:w-${breakpoint}` : undefined
-    const { privateKey, urlEndpoint } = this._sdk.options
-    // https://github.com/angular/angular/blob/19.2.5/packages/common/src/directives/ng_optimized_image/image_loaders/imagekit_loader.ts
-    const url = [
-      urlEndpoint,
-      transformationsString,
-      image.src.startsWith('/') ? image.src.substring(1) : image.src,
-    ]
-      .filter(isDefined)
-      .join('/')
+    const url = urlForBreakpoint(image.src, breakpoint)
     // https://github.com/imagekit-developer/imagekit-nodejs/blob/6.0.0/libs/url/builder.ts#L169
+    const { privateKey, urlEndpoint } = this._sdk.options
     return getSignature({
       privateKey,
       url,

--- a/scripts/src/images/cdn/apis/imagekit.ts
+++ b/scripts/src/images/cdn/apis/imagekit.ts
@@ -10,7 +10,7 @@ import {
 import { Image } from '@/app/common/images/image'
 import { ImageCdnApi, UNPUBLISHED_TAG } from '../image-cdn-api'
 import { URLSearchParams } from 'url'
-import { CLOUD_URL as IMAGEKIT_URL } from '@/app/common/images/cdn/imagekit'
+import { CLOUD_URL } from '@/app/common/images/cdn/imagekit'
 import { getSignature } from 'imagekit/dist/libs/url/builder'
 import { isDefined } from '@/app/common/is-defined'
 
@@ -34,7 +34,7 @@ export class Imagekit implements ImageCdnApi {
     }
 
     return new Imagekit({
-      urlEndpoint: IMAGEKIT_URL,
+      urlEndpoint: CLOUD_URL,
       publicKey: IMAGEKIT_PUBLIC_KEY,
       privateKey: IMAGEKIT_PRIVATE_KEY,
     })
@@ -58,7 +58,6 @@ export class Imagekit implements ImageCdnApi {
 
   private _imageAssetFromFileObject(fileObject: FileObject): Image {
     const alt = (fileObject.customMetadata as CustomMetadata)?.alt
-    const altMetadata: Pick<Image, 'alt'> = alt?.trim() ? { alt } : {}
     // Point to specific file version
     const queryParams = new URLSearchParams()
     queryParams.set(
@@ -72,7 +71,7 @@ export class Imagekit implements ImageCdnApi {
         `?${queryParams.toString()}`,
       height: fileObject.height,
       width: fileObject.width,
-      ...altMetadata,
+      ...(alt?.trim() ? { alt } : {}),
     }
   }
 

--- a/scripts/src/images/cdn/image-cdn-api.ts
+++ b/scripts/src/images/cdn/image-cdn-api.ts
@@ -6,9 +6,9 @@ export abstract class ImageCdnApi {
     includeSubdirectories?: boolean,
   ): Promise<readonly Image[]>
 
-  abstract signImageBreakpoint(
+  abstract signImage(
     image: Image,
-    breakpoint: number,
+    breakpoint: number | undefined,
   ): Promise<string>
 }
 

--- a/scripts/src/images/cdn/image-cdn-api.ts
+++ b/scripts/src/images/cdn/image-cdn-api.ts
@@ -5,6 +5,11 @@ export abstract class ImageCdnApi {
     path: string,
     includeSubdirectories?: boolean,
   ): Promise<readonly Image[]>
+
+  abstract signImageBreakpoint(
+    image: Image,
+    breakpoint: number,
+  ): Promise<string>
 }
 
 export const UNPUBLISHED_TAG = 'unpublished'

--- a/scripts/src/images/responsive/breakpoints.ts
+++ b/scripts/src/images/responsive/breakpoints.ts
@@ -11,6 +11,8 @@ export type BreakpointsFn = (
 ) => Promise<Breakpoints>
 
 export const getBreakpointsFn = async (): Promise<BreakpointsFn> => {
+  // eslint-disable-next-line
+  // @ts-ignore
   if (CDN_NAME === CLOUDINARY_CDN_NAME) {
     return getCloudinaryResponsiveBreakpointsApi()
   }

--- a/scripts/src/images/responsive/breakpoints.ts
+++ b/scripts/src/images/responsive/breakpoints.ts
@@ -1,4 +1,4 @@
-import { Image, ResponsiveImageBreakpoints } from '@/app/common/images/image'
+import { Breakpoints, Image } from '@/app/common/images/image'
 import { SourceSizeList } from '../../models/source-size-list'
 import { CDN_NAME } from '@/app/common/images/cdn'
 import { CDN_NAME as CLOUDINARY_CDN_NAME } from '@/app/common/images/cdn/cloudinary'
@@ -8,7 +8,7 @@ import { breakpointsFromSizesAndImage } from '../breakpoints-from-sizes-and-imag
 export type BreakpointsFn = (
   image: Image,
   sourceSizeList: SourceSizeList,
-) => Promise<ResponsiveImageBreakpoints>
+) => Promise<Breakpoints>
 
 export const getBreakpointsFn = async (): Promise<BreakpointsFn> => {
   if (CDN_NAME === CLOUDINARY_CDN_NAME) {

--- a/scripts/src/images/responsive/sign-responsive-image.ts
+++ b/scripts/src/images/responsive/sign-responsive-image.ts
@@ -1,0 +1,27 @@
+import {
+  areBreakpointsUnsigned,
+  ResponsiveImage,
+} from '@/app/common/images/image'
+import { Log } from '../../utils/log'
+import { ImageCdnApi } from '../cdn'
+
+export const signResponsiveImage = async (
+  responsiveImage: ResponsiveImage,
+  imageCdnApi: ImageCdnApi,
+): Promise<ResponsiveImage> => {
+  if (!areBreakpointsUnsigned(responsiveImage.breakpoints)) {
+    Log.warn('Breakpoints are already signed')
+    return responsiveImage
+  }
+  const { breakpoints, ...baseResponsiveImage } = responsiveImage
+  const breakpointsAndSignatures = await Promise.all(
+    breakpoints.map<Promise<[string, string]>>(async (breakpoint) => [
+      breakpoint.toString(),
+      await imageCdnApi.signImageBreakpoint(responsiveImage, breakpoint),
+    ]),
+  )
+  return {
+    ...baseResponsiveImage,
+    breakpoints: Object.fromEntries(breakpointsAndSignatures),
+  }
+}

--- a/scripts/src/images/responsive/sign-responsive-image.ts
+++ b/scripts/src/images/responsive/sign-responsive-image.ts
@@ -1,5 +1,6 @@
 import {
   areBreakpointsUnsigned,
+  ORIGINAL_SRC_BREAKPOINT,
   ResponsiveImage,
 } from '@/app/common/images/image'
 import { Log } from '../../utils/log'
@@ -15,10 +16,12 @@ export const signResponsiveImage = async (
   }
   const { breakpoints, ...baseResponsiveImage } = responsiveImage
   const breakpointsAndSignatures = await Promise.all(
-    breakpoints.map<Promise<[string, string]>>(async (breakpoint) => [
-      breakpoint.toString(),
-      await imageCdnApi.signImageBreakpoint(responsiveImage, breakpoint),
-    ]),
+    [undefined, ...breakpoints].map<Promise<[string, string]>>(
+      async (breakpoint) => [
+        (breakpoint ?? ORIGINAL_SRC_BREAKPOINT).toString(),
+        await imageCdnApi.signImage(responsiveImage, breakpoint),
+      ],
+    ),
   )
   return {
     ...baseResponsiveImage,

--- a/scripts/src/images/responsive/to-responsive-image.ts
+++ b/scripts/src/images/responsive/to-responsive-image.ts
@@ -7,9 +7,7 @@ import { resolveSequentially } from '../../utils/resolve-sequentially'
 export const toResponsiveImage = async (
   image: Image,
   sourceSizeList: SourceSizeList,
-  opts: Partial<{
-    withoutSizes: boolean
-  }> = {},
+  opts: ToResponsiveImageOpts = {},
 ): Promise<ResponsiveImage> => {
   const breakpointsFunction = await getBreakpointsFn()
   const responsiveImageWithoutSizes = {
@@ -33,6 +31,8 @@ export const toResponsiveImage = async (
     sizes: sourceSizeList.toString(),
   }
 }
+
+export type ToResponsiveImageOpts = Partial<{ withoutSizes: boolean }>
 
 export const toResponsiveImages = async (
   images: readonly Image[],

--- a/scripts/src/images/responsive/to-signed-responsive-image.ts
+++ b/scripts/src/images/responsive/to-signed-responsive-image.ts
@@ -1,0 +1,31 @@
+import { Image, ResponsiveImage } from '@/app/common/images/image'
+import { SourceSizeList } from '../../models/source-size-list'
+import { ImageCdnApi } from '../cdn'
+import { signResponsiveImage } from './sign-responsive-image'
+import {
+  toResponsiveImage,
+  ToResponsiveImageOpts,
+  toResponsiveImages,
+} from './to-responsive-image'
+
+export const toSignedResponsiveImage = async (
+  image: Image,
+  sourceSizeList: SourceSizeList,
+  imageCdnApi: ImageCdnApi,
+  opts: ToResponsiveImageOpts = {},
+): Promise<ResponsiveImage> =>
+  signResponsiveImage(
+    await toResponsiveImage(image, sourceSizeList, opts),
+    imageCdnApi,
+  )
+
+export const toSignedResponsiveImages = async (
+  images: readonly Image[],
+  sourceSizeList: SourceSizeList,
+  imageCdnApi: ImageCdnApi,
+): Promise<readonly ResponsiveImage[]> =>
+  Promise.all(
+    (await toResponsiveImages(images, sourceSizeList)).map((responsiveImage) =>
+      signResponsiveImage(responsiveImage, imageCdnApi),
+    ),
+  )

--- a/scripts/src/misc-images.ts
+++ b/scripts/src/misc-images.ts
@@ -7,7 +7,7 @@ import { join } from 'path'
 import { mkdir } from 'fs/promises'
 import { getImageCdnApi } from './images/cdn'
 import { ABOUT, LOGO } from './images/sizes'
-import { toResponsiveImage } from './images/responsive/to-responsive-image'
+import { toSignedResponsiveImage } from './images/responsive/to-signed-responsive-image'
 
 export const miscImages = async (): Promise<void> => {
   const imageCdnApi = await getImageCdnApi()
@@ -24,8 +24,16 @@ export const miscImages = async (): Promise<void> => {
     },
   )
   const miscImages: MiscImages = {
-    horizontalLogo: await toResponsiveImage(horizontalLogo, LOGO),
-    aboutPortrait: await toResponsiveImage(aboutPortrait, ABOUT),
+    horizontalLogo: await toSignedResponsiveImage(
+      horizontalLogo,
+      LOGO,
+      imageCdnApi,
+    ),
+    aboutPortrait: await toSignedResponsiveImage(
+      aboutPortrait,
+      ABOUT,
+      imageCdnApi,
+    ),
   }
   await writeJson(
     join(GENERATED_DATA_PATH, appendJsonExtension('misc-images')),

--- a/scripts/src/projects-content.ts
+++ b/scripts/src/projects-content.ts
@@ -2,7 +2,6 @@ import { isMain } from './utils/is-main'
 import { Log } from './utils/log'
 import { getImageCdnApi, ImageCdnApi } from './images/cdn'
 import PREVIEW_PRESET_JSON from '@/data/cms/album-presets/preview.json'
-import { ResponsiveImage } from '@/app/common/images/image'
 import {
   CmsProject,
   CmsProjectCredit,
@@ -33,7 +32,8 @@ import {
   PROJECT_LIST_ITEM,
 } from './images/sizes'
 import { resolveSequentially } from './utils/resolve-sequentially'
-import { toResponsiveImages } from './images/responsive/to-responsive-image'
+import { ResponsiveImage } from '@/app/common/images/image'
+import { toSignedResponsiveImages } from './images/responsive/to-signed-responsive-image'
 
 export const projectsContent = async () => {
   const expandedCmsProjects = await expandCmsProjects()
@@ -61,11 +61,12 @@ const expandCmsProject = async (
 ): Promise<ExpandedCmsProject> => {
   Log.info('Expanding project "%s"', cmsProject.slug)
   const projectImageDirectory = `${PROJECTS_DIR}/${cmsProject.slug}`
-  const previewImages = await toResponsiveImages(
+  const previewImages = await toSignedResponsiveImages(
     await imageCdnApi.getAllImagesInPath(
       `${projectImageDirectory}/${PREVIEW_PRESET_JSON.slug}`,
     ),
     PROJECT_LIST_ITEM,
+    imageCdnApi,
   )
   if (!previewImages.length) {
     throw new Error(`Project ${cmsProject.slug} has no preview images`)
@@ -103,7 +104,11 @@ const expandCmsProject = async (
         return {
           title,
           imageSizes: sourceSizeList.toString(),
-          images: await toResponsiveImages(images, sourceSizeList),
+          images: await toSignedResponsiveImages(
+            images,
+            sourceSizeList,
+            imageCdnApi,
+          ),
           size: preset.size,
         }
       },

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -17,6 +17,7 @@
     "src/**/*.ts",
     "../src/app/common/breakpoints.ts",
     "../src/app/common/directories.ts",
+    "../src/app/common/is-defined.ts",
     "../src/app/common/paddings.ts",
     "../src/app/common/social.ts",
     "../src/app/common/images/cdn/**/*.ts",

--- a/src/app/about-page/about-page.component.html
+++ b/src/app/about-page/about-page.component.html
@@ -13,6 +13,7 @@
       [alt]="_portrait.alt"
       [ngSrcset]="_portrait.breakpoints | toNgSrcSet"
       [sizes]="_portrait.sizes"
+      [loaderParams]="_portrait | toLoaderParams"
       priority="true"
     />
   }

--- a/src/app/about-page/about-page.component.spec.ts
+++ b/src/app/about-page/about-page.component.spec.ts
@@ -8,6 +8,7 @@ import { provideDummyOptimizedImage } from '../../test/provide-dummy-optimized-i
 import { NgOptimizedImage } from '@angular/common'
 import { testbedSetup } from '../../test/testbed-setup'
 import { ToNgSrcSet } from '@/app/common/images/to-ng-src-set'
+import { ToLoaderParams } from '@/app/common/images/loader-params'
 
 describe('AboutPageComponent', () => {
   let component: AboutPageComponent
@@ -23,6 +24,7 @@ describe('AboutPageComponent', () => {
           NgOptimizedImage,
           MockComponents(SocialComponent, ResumeComponent),
           ToNgSrcSet,
+          ToLoaderParams,
         ],
       },
     })

--- a/src/app/about-page/about-page.component.ts
+++ b/src/app/about-page/about-page.component.ts
@@ -6,12 +6,19 @@ import { NgOptimizedImage } from '@angular/common'
 import { ResumeComponent } from './resume/resume.component'
 import { SocialComponent } from './social/social.component'
 import { ToNgSrcSet } from '@/app/common/images/to-ng-src-set'
+import { ToLoaderParams } from '@/app/common/images/loader-params'
 
 @Component({
   templateUrl: './about-page.component.html',
   styleUrls: ['./about-page.component.scss'],
   standalone: true,
-  imports: [SocialComponent, ResumeComponent, NgOptimizedImage, ToNgSrcSet],
+  imports: [
+    SocialComponent,
+    ResumeComponent,
+    NgOptimizedImage,
+    ToNgSrcSet,
+    ToLoaderParams,
+  ],
 })
 export class AboutPageComponent {
   protected readonly _title: string = aboutPageContents.title

--- a/src/app/common/images/cdn/cloudinary.ts
+++ b/src/app/common/images/cdn/cloudinary.ts
@@ -1,10 +1,40 @@
-import { provideCloudinaryLoader } from '@angular/common'
+import { IMAGE_LOADER, ImageLoader } from '@angular/common'
+import { Provider } from '@angular/core'
+import { LoaderParams } from '@/app/common/images/image'
 
 export const CDN_NAME = 'cloudinary'
 export const BASE_URL = 'https://res.cloudinary.com/'
 export const CLOUD_NAME = 'chrislb'
 export const URL = `${BASE_URL}${CLOUD_NAME}`
-export const provideResponsiveImageLoader = () => provideCloudinaryLoader(URL)
+export const provideResponsiveImageLoader = (): Provider => ({
+  provide: IMAGE_LOADER,
+  useValue: cloudinaryImageLoader,
+})
+
+export const IMAGE_DELIVERY_TYPE = 'authenticated'
+
+const cloudinaryImageLoader: ImageLoader = (config) => {
+  const loaderParams = (config.loaderParams ?? {}) as LoaderParams
+
+  const signature = config.width
+    ? (loaderParams.signaturesByBreakpoint ?? {})[config.width.toString()]
+    : undefined
+
+  const widthTransformation = config.width ? `w_${config.width}` : undefined
+  return [
+    URL,
+    'image',
+    IMAGE_DELIVERY_TYPE,
+    signature,
+    [...ANTE_TRANSFORMATIONS, widthTransformation].filter(isDefined).join(','),
+    config.src,
+  ]
+    .filter(isDefined)
+    .join('/')
+}
+
+const isDefined = <T>(x: T | undefined): x is T => x !== undefined
+
 //👇 Applying default transformations from Angular built-in loader
 // https://github.com/angular/angular/blob/19.2.5/packages/common/src/directives/ng_optimized_image/image_loaders/cloudinary_loader.ts#L58-L60
 export const ANTE_TRANSFORMATIONS = ['q_auto', 'f_auto']

--- a/src/app/common/images/cdn/cloudinary.ts
+++ b/src/app/common/images/cdn/cloudinary.ts
@@ -15,14 +15,12 @@ export const provideResponsiveImageLoader = (): Provider => ({
 export const IMAGE_DELIVERY_TYPE = 'authenticated'
 
 const cloudinaryImageLoader: ImageLoader = (config) => {
-  const widthTransformation = config.width ? `w_${config.width}` : undefined
-
   return [
     CLOUD_URL,
     'image',
     IMAGE_DELIVERY_TYPE,
     getBreakpointSignatureFromLoaderConfig(config),
-    [...ANTE_TRANSFORMATIONS, widthTransformation].filter(isDefined).join(','),
+    getRawTransformationForBreakpoint(config.width),
     config.src,
   ]
     .filter(isDefined)
@@ -31,4 +29,9 @@ const cloudinaryImageLoader: ImageLoader = (config) => {
 
 //👇 Applying default transformations from Angular built-in loader
 // https://github.com/angular/angular/blob/19.2.5/packages/common/src/directives/ng_optimized_image/image_loaders/cloudinary_loader.ts#L58-L60
-export const ANTE_TRANSFORMATIONS = ['q_auto', 'f_auto']
+export const getRawTransformationForBreakpoint = (
+  width: number | undefined,
+): string => {
+  const widthTransformation = width ? `w_${width}` : undefined
+  return ['q_auto', 'f_auto', widthTransformation].filter(isDefined).join(',')
+}

--- a/src/app/common/images/cdn/cloudinary.ts
+++ b/src/app/common/images/cdn/cloudinary.ts
@@ -1,11 +1,12 @@
 import { IMAGE_LOADER, ImageLoader } from '@angular/common'
 import { Provider } from '@angular/core'
 import { LoaderParams } from '@/app/common/images/image'
+import { isDefined } from '@/app/common/is-defined'
 
 export const CDN_NAME = 'cloudinary'
 export const BASE_URL = 'https://res.cloudinary.com/'
 export const CLOUD_NAME = 'chrislb'
-export const URL = `${BASE_URL}${CLOUD_NAME}`
+export const CLOUD_URL = `${BASE_URL}${CLOUD_NAME}`
 export const provideResponsiveImageLoader = (): Provider => ({
   provide: IMAGE_LOADER,
   useValue: cloudinaryImageLoader,
@@ -21,8 +22,9 @@ const cloudinaryImageLoader: ImageLoader = (config) => {
     : undefined
 
   const widthTransformation = config.width ? `w_${config.width}` : undefined
+
   return [
-    URL,
+    CLOUD_URL,
     'image',
     IMAGE_DELIVERY_TYPE,
     signature,
@@ -32,8 +34,6 @@ const cloudinaryImageLoader: ImageLoader = (config) => {
     .filter(isDefined)
     .join('/')
 }
-
-const isDefined = <T>(x: T | undefined): x is T => x !== undefined
 
 //👇 Applying default transformations from Angular built-in loader
 // https://github.com/angular/angular/blob/19.2.5/packages/common/src/directives/ng_optimized_image/image_loaders/cloudinary_loader.ts#L58-L60

--- a/src/app/common/images/cdn/cloudinary.ts
+++ b/src/app/common/images/cdn/cloudinary.ts
@@ -1,6 +1,6 @@
 import { IMAGE_LOADER, ImageLoader } from '@angular/common'
 import { Provider } from '@angular/core'
-import { LoaderParams } from '@/app/common/images/image'
+import { getBreakpointSignatureFromLoaderConfig } from '@/app/common/images/image'
 import { isDefined } from '@/app/common/is-defined'
 
 export const CDN_NAME = 'cloudinary'
@@ -15,19 +15,13 @@ export const provideResponsiveImageLoader = (): Provider => ({
 export const IMAGE_DELIVERY_TYPE = 'authenticated'
 
 const cloudinaryImageLoader: ImageLoader = (config) => {
-  const loaderParams = (config.loaderParams ?? {}) as LoaderParams
-
-  const signature = config.width
-    ? (loaderParams.signaturesByBreakpoint ?? {})[config.width.toString()]
-    : undefined
-
   const widthTransformation = config.width ? `w_${config.width}` : undefined
 
   return [
     CLOUD_URL,
     'image',
     IMAGE_DELIVERY_TYPE,
-    signature,
+    getBreakpointSignatureFromLoaderConfig(config),
     [...ANTE_TRANSFORMATIONS, widthTransformation].filter(isDefined).join(','),
     config.src,
   ]

--- a/src/app/common/images/cdn/cloudinary.ts
+++ b/src/app/common/images/cdn/cloudinary.ts
@@ -5,3 +5,6 @@ export const BASE_URL = 'https://res.cloudinary.com/'
 export const CLOUD_NAME = 'chrislb'
 export const URL = `${BASE_URL}${CLOUD_NAME}`
 export const provideResponsiveImageLoader = () => provideCloudinaryLoader(URL)
+//👇 Applying default transformations from Angular built-in loader
+// https://github.com/angular/angular/blob/19.2.5/packages/common/src/directives/ng_optimized_image/image_loaders/cloudinary_loader.ts#L58-L60
+export const ANTE_TRANSFORMATIONS = ['q_auto', 'f_auto']

--- a/src/app/common/images/cdn/imagekit.ts
+++ b/src/app/common/images/cdn/imagekit.ts
@@ -11,16 +11,7 @@ export const provideResponsiveImageLoader = () => ({
   useValue: imageKitImageLoader,
 })
 const imageKitImageLoader: ImageLoader = (config) => {
-  const widthTransformation = config.width ? `w-${config.width}` : undefined
-
-  // https://github.com/angular/angular/blob/19.2.5/packages/common/src/directives/ng_optimized_image/image_loaders/imagekit_loader.ts
-  const unsignedUrl = [
-    CLOUD_URL,
-    widthTransformation ? `tr:${widthTransformation}` : undefined,
-    config.src.startsWith('/') ? config.src.substring(1) : config.src,
-  ]
-    .filter(isDefined)
-    .join('/')
+  const unsignedUrl = urlForBreakpoint(config.src, config.width)
 
   const signature = getBreakpointSignatureFromLoaderConfig(config)
   if (!signature) return unsignedUrl
@@ -29,4 +20,19 @@ const imageKitImageLoader: ImageLoader = (config) => {
   const signedUrl = new URL(unsignedUrl)
   signedUrl.searchParams.set('ik-s', signature)
   return signedUrl.href
+}
+
+// https://github.com/angular/angular/blob/19.2.5/packages/common/src/directives/ng_optimized_image/image_loaders/imagekit_loader.ts
+export const urlForBreakpoint = (
+  src: string,
+  width: number | undefined,
+): string => {
+  const widthTransformation = width ? `w-${width}` : undefined
+  return [
+    CLOUD_URL,
+    widthTransformation ? `tr:${widthTransformation}` : undefined,
+    src.startsWith('/') ? src.substring(1) : src,
+  ]
+    .filter(isDefined)
+    .join('/')
 }

--- a/src/app/common/images/cdn/imagekit.ts
+++ b/src/app/common/images/cdn/imagekit.ts
@@ -1,5 +1,5 @@
 import { IMAGE_LOADER, ImageLoader } from '@angular/common'
-import { LoaderParams } from '@/app/common/images/image'
+import { getBreakpointSignatureFromLoaderConfig } from '@/app/common/images/image'
 import { isDefined } from '@/app/common/is-defined'
 
 export const CDN_NAME = 'imagekit'
@@ -11,12 +11,6 @@ export const provideResponsiveImageLoader = () => ({
   useValue: imageKitImageLoader,
 })
 const imageKitImageLoader: ImageLoader = (config) => {
-  const loaderParams = (config.loaderParams ?? {}) as LoaderParams
-
-  const signature = config.width
-    ? (loaderParams.signaturesByBreakpoint ?? {})[config.width.toString()]
-    : undefined
-
   const widthTransformation = config.width ? `w-${config.width}` : undefined
 
   // https://github.com/angular/angular/blob/19.2.5/packages/common/src/directives/ng_optimized_image/image_loaders/imagekit_loader.ts
@@ -27,11 +21,12 @@ const imageKitImageLoader: ImageLoader = (config) => {
   ]
     .filter(isDefined)
     .join('/')
+
+  const signature = getBreakpointSignatureFromLoaderConfig(config)
   if (!signature) return unsignedUrl
 
   // https://imagekit.io/docs/media-delivery-basic-security#how-to-generate-signed-urls
   const signedUrl = new URL(unsignedUrl)
   signedUrl.searchParams.set('ik-s', signature)
-
   return signedUrl.href
 }

--- a/src/app/common/images/cdn/imagekit.ts
+++ b/src/app/common/images/cdn/imagekit.ts
@@ -1,7 +1,37 @@
-import { provideImageKitLoader } from '@angular/common'
+import { IMAGE_LOADER, ImageLoader } from '@angular/common'
+import { LoaderParams } from '@/app/common/images/image'
+import { isDefined } from '@/app/common/is-defined'
 
 export const CDN_NAME = 'imagekit'
 export const BASE_URL = 'https://ik.imagekit.io/'
 const CLOUD_NAME = 'chrislb'
-export const URL = `${BASE_URL}${CLOUD_NAME}`
-export const provideResponsiveImageLoader = () => provideImageKitLoader(URL)
+export const CLOUD_URL = `${BASE_URL}${CLOUD_NAME}`
+export const provideResponsiveImageLoader = () => ({
+  provide: IMAGE_LOADER,
+  useValue: imageKitImageLoader,
+})
+const imageKitImageLoader: ImageLoader = (config) => {
+  const loaderParams = (config.loaderParams ?? {}) as LoaderParams
+
+  const signature = config.width
+    ? (loaderParams.signaturesByBreakpoint ?? {})[config.width.toString()]
+    : undefined
+
+  const widthTransformation = config.width ? `w-${config.width}` : undefined
+
+  // https://github.com/angular/angular/blob/19.2.5/packages/common/src/directives/ng_optimized_image/image_loaders/imagekit_loader.ts
+  const unsignedUrl = [
+    CLOUD_URL,
+    widthTransformation ? `tr:${widthTransformation}` : undefined,
+    config.src.startsWith('/') ? config.src.substring(1) : config.src,
+  ]
+    .filter(isDefined)
+    .join('/')
+  if (!signature) return unsignedUrl
+
+  // https://imagekit.io/docs/media-delivery-basic-security#how-to-generate-signed-urls
+  const signedUrl = new URL(unsignedUrl)
+  signedUrl.searchParams.set('ik-s', signature)
+
+  return signedUrl.href
+}

--- a/src/app/common/images/cdn/index.ts
+++ b/src/app/common/images/cdn/index.ts
@@ -1,5 +1,5 @@
 // 👇 To switch CDN
-export { CDN_NAME, BASE_URL, provideResponsiveImageLoader } from './cloudinary'
+export { CDN_NAME, BASE_URL, provideResponsiveImageLoader } from './imagekit'
 
 import { CDN_NAME as CLOUDINARY_NAME } from './cloudinary'
 import { CDN_NAME as IMAGEKIT_NAME } from './imagekit'

--- a/src/app/common/images/image.ts
+++ b/src/app/common/images/image.ts
@@ -1,3 +1,5 @@
+import { ImageLoaderConfig } from '@angular/common'
+
 export interface Image {
   src: string
   width: number
@@ -20,4 +22,14 @@ export const areBreakpointsUnsigned = (
 
 export interface LoaderParams {
   signaturesByBreakpoint?: SignaturesByBreakpoint
+}
+
+export const getBreakpointSignatureFromLoaderConfig = (
+  loaderConfig: ImageLoaderConfig,
+) => {
+  const loaderParams = (loaderConfig.loaderParams ?? {}) as LoaderParams
+
+  return loaderConfig.width
+    ? (loaderParams.signaturesByBreakpoint ?? {})[loaderConfig.width.toString()]
+    : undefined
 }

--- a/src/app/common/images/image.ts
+++ b/src/app/common/images/image.ts
@@ -16,6 +16,8 @@ export type ResponsiveImageBreakpoints = Breakpoints | SignaturesByBreakpoint
 export type Breakpoints = readonly number[]
 export type SignaturesByBreakpoint = Record<string, string>
 
+export const ORIGINAL_SRC_BREAKPOINT = ''
+
 export const areBreakpointsUnsigned = (
   breakpoints: ResponsiveImageBreakpoints,
 ): breakpoints is Breakpoints => Array.isArray(breakpoints)
@@ -28,8 +30,6 @@ export const getBreakpointSignatureFromLoaderConfig = (
   loaderConfig: ImageLoaderConfig,
 ) => {
   const loaderParams = (loaderConfig.loaderParams ?? {}) as LoaderParams
-
-  return loaderConfig.width
-    ? (loaderParams.signaturesByBreakpoint ?? {})[loaderConfig.width.toString()]
-    : undefined
+  const width = loaderConfig.width?.toString() ?? ORIGINAL_SRC_BREAKPOINT
+  return (loaderParams.signaturesByBreakpoint ?? {})[width]
 }

--- a/src/app/common/images/image.ts
+++ b/src/app/common/images/image.ts
@@ -17,3 +17,7 @@ export type SignaturesByBreakpoint = Record<string, string>
 export const areBreakpointsUnsigned = (
   breakpoints: ResponsiveImageBreakpoints,
 ): breakpoints is Breakpoints => Array.isArray(breakpoints)
+
+export interface LoaderParams {
+  signaturesByBreakpoint?: SignaturesByBreakpoint
+}

--- a/src/app/common/images/image.ts
+++ b/src/app/common/images/image.ts
@@ -10,4 +10,10 @@ export type ResponsiveImage = Image & {
   readonly sizes?: string
 }
 
-export type ResponsiveImageBreakpoints = readonly number[]
+export type ResponsiveImageBreakpoints = Breakpoints | SignaturesByBreakpoint
+export type Breakpoints = readonly number[]
+export type SignaturesByBreakpoint = Record<string, string>
+
+export const areBreakpointsUnsigned = (
+  breakpoints: ResponsiveImageBreakpoints,
+): breakpoints is Breakpoints => Array.isArray(breakpoints)

--- a/src/app/common/images/loader-params.ts
+++ b/src/app/common/images/loader-params.ts
@@ -1,0 +1,14 @@
+import { Pipe, PipeTransform } from '@angular/core'
+import { areBreakpointsUnsigned, LoaderParams, ResponsiveImage } from './image'
+
+@Pipe({ name: 'toLoaderParams', standalone: true, pure: true })
+export class ToLoaderParams implements PipeTransform {
+  transform(image: ResponsiveImage): LoaderParams {
+    const { breakpoints } = image
+    return {
+      signaturesByBreakpoint: areBreakpointsUnsigned(breakpoints)
+        ? undefined
+        : breakpoints,
+    }
+  }
+}

--- a/src/app/common/images/to-ng-src-set.ts
+++ b/src/app/common/images/to-ng-src-set.ts
@@ -1,6 +1,7 @@
 import { Pipe, PipeTransform } from '@angular/core'
 import {
   areBreakpointsUnsigned,
+  ORIGINAL_SRC_BREAKPOINT,
   ResponsiveImageBreakpoints,
 } from '@/app/common/images/image'
 
@@ -9,7 +10,9 @@ export class ToNgSrcSet implements PipeTransform {
   transform(breakpoints: ResponsiveImageBreakpoints): string {
     const unsignedBreakpoints = areBreakpointsUnsigned(breakpoints)
       ? breakpoints
-      : Object.keys(breakpoints).map((breakpoint) => parseInt(breakpoint))
+      : Object.keys(breakpoints)
+          .filter((breakpoint) => breakpoint !== ORIGINAL_SRC_BREAKPOINT)
+          .map((breakpoint) => parseInt(breakpoint))
     return unsignedBreakpoints.map((breakpoint) => `${breakpoint}w`).join(', ')
   }
 }

--- a/src/app/common/images/to-ng-src-set.ts
+++ b/src/app/common/images/to-ng-src-set.ts
@@ -1,12 +1,15 @@
 import { Pipe, PipeTransform } from '@angular/core'
-import { ResponsiveImageBreakpoints } from './image'
+import {
+  areBreakpointsUnsigned,
+  ResponsiveImageBreakpoints,
+} from '@/app/common/images/image'
 
 @Pipe({ name: 'toNgSrcSet', standalone: true, pure: true })
 export class ToNgSrcSet implements PipeTransform {
-  transform(breakpoints: readonly number[]) {
-    return toNgSrcSet(breakpoints)
+  transform(breakpoints: ResponsiveImageBreakpoints): string {
+    const unsignedBreakpoints = areBreakpointsUnsigned(breakpoints)
+      ? breakpoints
+      : Object.keys(breakpoints).map((breakpoint) => parseInt(breakpoint))
+    return unsignedBreakpoints.map((breakpoint) => `${breakpoint}w`).join(', ')
   }
 }
-
-export const toNgSrcSet = (breakpoints: ResponsiveImageBreakpoints): string =>
-  breakpoints.map((breakpoint) => `${breakpoint}w`).join(', ')

--- a/src/app/common/is-defined.ts
+++ b/src/app/common/is-defined.ts
@@ -1,0 +1,1 @@
+export const isDefined = <T>(x: T | undefined): x is T => x !== undefined

--- a/src/app/logo/logo.component.html
+++ b/src/app/logo/logo.component.html
@@ -8,6 +8,7 @@
       [priority]="true"
       [ngSrcset]="_logo.breakpoints | toNgSrcSet"
       [sizes]="_logo.sizes"
+      [loaderParams]="_logo | toLoaderParams"
     />
   </a>
 }

--- a/src/app/logo/logo.component.ts
+++ b/src/app/logo/logo.component.ts
@@ -3,13 +3,14 @@ import { MISC_IMAGES } from '../common/images/misc-images'
 import { NgOptimizedImage } from '@angular/common'
 import { RouterLink } from '@angular/router'
 import { ToNgSrcSet } from '@/app/common/images/to-ng-src-set'
+import { ToLoaderParams } from '@/app/common/images/loader-params'
 
 @Component({
   selector: 'app-logo',
   templateUrl: './logo.component.html',
   styleUrls: ['./logo.component.scss'],
   standalone: true,
-  imports: [RouterLink, NgOptimizedImage, ToNgSrcSet],
+  imports: [RouterLink, NgOptimizedImage, ToNgSrcSet, ToLoaderParams],
 })
 export class LogoComponent {
   protected readonly _logo = MISC_IMAGES.horizontalLogo

--- a/src/app/projects/images-swiper/images-swiper.component.html
+++ b/src/app/projects/images-swiper/images-swiper.component.html
@@ -24,6 +24,7 @@
           [fill]="true"
           [priority]="priority() && i < (maxSlidesPerView ?? 0)"
           [alt]="image.alt || 'Image'"
+          [loaderParams]="image | toLoaderParams"
         />
       </swiper-slide>
     }

--- a/src/app/projects/images-swiper/images-swiper.component.ts
+++ b/src/app/projects/images-swiper/images-swiper.component.ts
@@ -17,6 +17,7 @@ import { ResponsiveImage } from '../../common/images/image'
 import { SwiperDirective } from './swiper.directive'
 import { NgOptimizedImage } from '@angular/common'
 import { ToNgSrcSet } from '@/app/common/images/to-ng-src-set'
+import { ToLoaderParams } from '@/app/common/images/loader-params'
 
 // There's no fancier way to install Web Components in Angular :P
 // https://stackoverflow.com/a/75353889/3263250
@@ -27,7 +28,7 @@ registerSwiper()
   templateUrl: './images-swiper.component.html',
   styleUrls: ['./images-swiper.component.scss'],
   standalone: true,
-  imports: [SwiperDirective, NgOptimizedImage, ToNgSrcSet],
+  imports: [SwiperDirective, NgOptimizedImage, ToNgSrcSet, ToLoaderParams],
   // Use swiper web components
   // A better approach would be to declare those but there's no easy way
   // https://stackoverflow.com/a/43012920/3263250


### PR DESCRIPTION
Each image transformation has its cost in the image CDN provider. By default, you can take an image URL, change it and generate another transform. To avoid transformations other than the required for the generated breakpoints, a signature can be added to image URLs. So doing that in order to avoid consuming the transformation credits.

In order to do this:

1. **Breakpoints for a responsive image can be now a list of numbers (widths) or a map where keys are breakpoints (widths) and values are their signatures**. Or in few words, they can be unsigned or signed. Implement a method in each Image CDN API to sign an image breakpoint. Then, add some utils to call this API in a friendly fashion. Finally, for the app to read the new breakpoints, `ToNgSrcSet` pipe has been updated to just read keys if signed breakpoints are given.
2. **Custom image loaders**. Built-in image loaders for Cloudinary and Imagekit in Angular do not support signed URLs. So adding custom ones based on the built-in ones. Signatures are passed to them via the `loaderParams` of `ImageConfig`. To fill params, a `toLoaderParams` pipe has been added.
3. **Take into account `src` without transformation**. Must be signed too, otherwise older browsers without support for `srcSet` attribute won't display any image. The trick here has been to add it in the map containing signatures by breakpoint where the breakpoint is the empty string.

Finally, this PR also changes the CDN to use to serve images to Imagekit. Given the change can't be done without changing the image URLs if using Cloudinary. This way, we can:
1. Configure to upload assets to authenticated by default. Re-upload all assets. Switch to authenticated assets delivery URLs.
1. Wait for Cloudinary credits to renew. Almost 50% of free tier spent in a week after playing around :S

Some minor changes: `extends -> implements` on `ImageCdnApi`.

# Signed URLs per CDN
Discovered some interesting things whilst playing with permissions

## ImageKit
Quite straight-forward. Changing the signed URL setting to restrict all requests forces all images to have a signature in their URL in order to be served. Otherwise, the request for the image fails with a 401 status code and a page containing "Invalid request signature" message.

In the signature side of things, however, had to look at the implementation to see why signatures generated didn't match. Reason was that there's some hardcoded timestamp added by default when no timestamp is provided. 

## Cloudinary
Aaaah Cloudinary, the fun starts here. There are [several ways](https://cloudinary.com/documentation/control_access_to_media) to restrict access to images. Naming is quite confusing IMO

TL;DR:
 - **Private assets**: only derived assets can be accessed publicly. Accessing original seems that requires generating a URL with some SDK method that generates a URL. Which allows to set a timeframe where the URL to access the original asset will be valid. Not the same method to generate signed URLs though 🤔 The URL is like `https://api.cloudinary.com/v1_1/private-demo/image/download?api_key=824..`. Quite different from regular delivery URLs. Derived assets can be restricted by enabling strict transformations. It says that this mode can be set when uploading a file. However, doesn't indicate if can be changed for an already uploaded asset. Nothing in the UI regarding to it either.
 - **Authenticated assets**. An authenticated asset requires that the URL is signed to access the original asset or any derivation / transformation of it. However there are things to take into account in here:
   - In the web UI, the "Access control" doesn't change anything. This is because access control != authenticated delivery URL. Access control has 2 options: public and restricted. Restricted allows to restrict access to an image for some time. Can be a bit confusing. And then you open the popup to explain what does "Access control" means when changing the default  upload settings and... [^1]. Later [you read docs and more words for same things like _token_, and _anonymous_ appear](https://cloudinary.com/documentation/control_access_to_media#access_controlled_media_assets). TL;DR: authenticated is to force all delivery URLs to be authenticated (there are several methods). Access control is to restrict (in restricted mode) an asset to require a token to be accessed (which can be time-limited). If public, no token is required. Not sure what happens if an asset is authenticated + restricted at same time :P Does the image require a token? Or the authenticated delivery URL is enough. Guess a token, as sounds more restrictive cause can be time-sensitive too. Btw access control needs an advanced plan. Finally, checkout [^2] to see how an authenticated asset looks like in the web UI.
   - A call to the [rename API](https://cloudinary.com/documentation/image_upload_api_reference#rename_public_id) is needed in order to set this mode for an asset. If that's not set when uploading the image. Which is right now changed in the default upload settings.
   - The delivery URL changes. Instead of URL starting with `{cloudUrl}/image/upload`, the URL starts with `{cloudUrl}/image/authenticated`. This is very important to take into account as changing an asset to be authenticated requires changing its delivery URLs. 
   - Weird things happen when changing from / to `upload` from / to `authenticated` types using the rename API. First time, when changing an asset from `authenticated` back to `public`, the URL without format didn't work anymore. It returns a 404 status code. That URL was something like: `{cloudUrl}/image/upload/example`. However, if adding the format extension of the asset, it worked: `{cloudUrl}/image/upload/example.jpg`. Adding cache invalidation to the rename API options didn't solve the issue (did it for both changes: `upload` -> `authenticated` and viceversa). Once it's broken, it's broken. Didn't wait more than some seconds to see results though. Then, a later try revealed that if first accessing the URL with format when it's public, changing it to authenticated, back to public, then the URL with format isn't available anymore. Quite weird. Fortunately, re-uploading the asset fixes the issue.
 - **Strict transformations**. When this setting is enabled, all transformations are required to be authenticated or otherwise won't be served. There are some exceptions that can be set: per referrer domain & allowing specific named transformations. 
 - **Restrict URL delivery types**. Cloudinary has some fancy features to allow fetching images from external sources in order to provide their transformations over them + caching. Those can be accessed by giving another delivery type in the delivery URL (`{cloudName}/image/{deliveryType}`). 

I think the best option in here is authenticated assets. Given it gives the highest security as both the asset and its transformations require a signed URL. Also, this way we can only allow authenticated URLs in settings hence we ensure no `upload` / `public` assets are accessed. Because when you enter the transformations UI via the site, it generates some sample public assets to play with (if not there). Whose names are static. Hence those could be used by a malicious entity to perform a DoS attack by exhausting transformations / bandwidth querying those.

The caveat of this is that if later adding the Cloudinary image selector to the Decap CMS, images won't be able to be seen in the CMS as they won't be signed. However, not thinking of adding that integration for now. 

**UPDATE**: Cloudinary images have been re-uploaded and are now `authenticated`. Default settings have been changed for that purpose. And also this way, new images will be authenticated too.

[^1]: ![image](https://github.com/user-attachments/assets/309d2bfb-c251-409f-b81d-0d01ba4f539a)
[^2]: ![image](https://github.com/user-attachments/assets/e1b62a69-4a8f-4569-b79e-def647ef7118)
