### PR TITLE
feat: embed version in Cloudinary image src

### DIFF
--- a/src/app/common/images/image.ts
+++ b/src/app/common/images/image.ts
@@ -3,7 +3,6 @@ export interface Image {
   width: number
   height: number
   alt?: string
-  params?: Record<string, string>
 }
 
 export type ResponsiveImage = Image & {


### PR DESCRIPTION
This is a _feat-factor_ kind of PR. In order to display a specific version of the image, so that uploading a new image version doesn't alter the site directly, the version to display was stored in `params` of the image. With the intention of later using a custom loader that reads it and forms the URL with it. However, after seeing how URLs are formed, seems that we can actually embed the version in the `image.src` and keep the same loader and show a specific version of the image. Given that when forming a Cloudinary URL, it ends with:

`v${version}/{asset_id/public_id}`

This way, less complexity around and we can display a specific version of a Cloudinary image. Which will also simplify the signed URLs PR 
