### PR TITLE
refactor: rename image CDN APIs

### DIFF
--- a/scripts/src/images/cdn/apis/cloudinary.ts
+++ b/scripts/src/images/cdn/apis/cloudinary.ts
@@ -1,4 +1,8 @@
-import { ImageCdnApi, UNPUBLISHED_TAG } from '../image-cdn-api'
+import {
+  GetUrlSignatureOptions,
+  ImageCdnApi,
+  UNPUBLISHED_TAG,
+} from '../image-cdn-api'
 import { ConfigOptions, v2 as cloudinary } from 'cloudinary'
 import dotenv from 'dotenv'
 import { Log } from '../../../utils/log'
@@ -7,7 +11,7 @@ import {
   getRawTransformationForBreakpoint,
   IMAGE_DELIVERY_TYPE,
 } from '@/app/common/images/cdn/cloudinary'
-import { Breakpoints, Image, ResponsiveImage } from '@/app/common/images/image'
+import { Breakpoints, Image } from '@/app/common/images/image'
 import { SCRIPTS_CACHE_PATH } from '../../../utils/paths'
 import { mkdir } from 'fs/promises'
 import {
@@ -60,7 +64,7 @@ export class Cloudinary implements ImageCdnApi {
     return new Cloudinary()
   }
 
-  async getAllImagesInPath(path: string): Promise<readonly Image[]> {
+  async findByPath(path: string): Promise<readonly Image[]> {
     const response = await cloudinary.api.resources_by_asset_folder(path, {
       max_results: 50, // the default right now, but to be specific & consistent over time
       resource_type: 'image',
@@ -114,11 +118,14 @@ export class Cloudinary implements ImageCdnApi {
     return sortedAndFullWidthBreakpoints
   }
 
-  async signImage(image: ResponsiveImage, breakpoint: number | undefined) {
+  async getUrlSignature(
+    publicId: string,
+    { breakpoint }: GetUrlSignatureOptions,
+  ) {
     // Seems there's no way to get the raw sig using Cloudinary's Node.js SDK
     // https://github.com/cloudinary/cloudinary_npm/blob/2.6.0/lib/utils/index.js#L894-L898
     // So extracting it from the URL instead to avoid signing manually
-    const imageUrl = cloudinary.url(image.src, {
+    const imageUrl = cloudinary.url(publicId, {
       urlAnalytics: false,
       sign_url: true,
       type: IMAGE_DELIVERY_TYPE,

--- a/scripts/src/images/cdn/apis/imagekit.ts
+++ b/scripts/src/images/cdn/apis/imagekit.ts
@@ -8,7 +8,11 @@ import {
   ImageKitOptions,
 } from 'imagekit/dist/libs/interfaces'
 import { Image } from '@/app/common/images/image'
-import { ImageCdnApi, UNPUBLISHED_TAG } from '../image-cdn-api'
+import {
+  GetUrlSignatureOptions,
+  ImageCdnApi,
+  UNPUBLISHED_TAG,
+} from '../image-cdn-api'
 import { URLSearchParams } from 'url'
 import { CLOUD_URL, urlForBreakpoint } from '@/app/common/images/cdn/imagekit'
 import { getSignature } from 'imagekit/dist/libs/url/builder'
@@ -39,7 +43,7 @@ export class Imagekit implements ImageCdnApi {
     })
   }
 
-  async getAllImagesInPath(path: string): Promise<readonly Image[]> {
+  async findByPath(path: string): Promise<readonly Image[]> {
     const searchQuery = `tags NOT IN ${JSON.stringify([UNPUBLISHED_TAG])}`
     const response = await this._sdk.listFiles({
       searchQuery,
@@ -74,11 +78,11 @@ export class Imagekit implements ImageCdnApi {
     }
   }
 
-  async signImage(
-    image: Image,
-    breakpoint: number | undefined,
+  async getUrlSignature(
+    path: string,
+    { breakpoint }: GetUrlSignatureOptions,
   ): Promise<string> {
-    const url = urlForBreakpoint(image.src, breakpoint)
+    const url = urlForBreakpoint(path, breakpoint)
     // https://github.com/imagekit-developer/imagekit-nodejs/blob/6.0.0/libs/url/builder.ts#L169
     const { privateKey, urlEndpoint } = this._sdk.options
     return getSignature({

--- a/scripts/src/images/cdn/image-cdn-api.ts
+++ b/scripts/src/images/cdn/image-cdn-api.ts
@@ -1,15 +1,16 @@
 import { Image } from '@/app/common/images/image'
 
 export abstract class ImageCdnApi {
-  abstract getAllImagesInPath(
-    path: string,
-    includeSubdirectories?: boolean,
-  ): Promise<readonly Image[]>
+  abstract findByPath(path: string): Promise<readonly Image[]>
 
-  abstract signImage(
-    image: Image,
-    breakpoint: number | undefined,
+  abstract getUrlSignature(
+    path: string,
+    opts?: GetUrlSignatureOptions,
   ): Promise<string>
+}
+
+export interface GetUrlSignatureOptions {
+  breakpoint?: number
 }
 
 export const UNPUBLISHED_TAG = 'unpublished'

--- a/scripts/src/images/responsive/sign-responsive-image.ts
+++ b/scripts/src/images/responsive/sign-responsive-image.ts
@@ -19,7 +19,7 @@ export const signResponsiveImage = async (
     [undefined, ...breakpoints].map<Promise<[string, string]>>(
       async (breakpoint) => [
         (breakpoint ?? ORIGINAL_SRC_BREAKPOINT).toString(),
-        await imageCdnApi.signImage(responsiveImage, breakpoint),
+        await imageCdnApi.getUrlSignature(responsiveImage.src, { breakpoint }),
       ],
     ),
   )

--- a/scripts/src/misc-images.ts
+++ b/scripts/src/misc-images.ts
@@ -13,7 +13,7 @@ export const miscImages = async (): Promise<void> => {
   const imageCdnApi = await getImageCdnApi()
   await mkdir(GENERATED_DATA_PATH, { recursive: true })
   Log.info('Looking for misc images')
-  const images = await imageCdnApi.getAllImagesInPath('misc')
+  const images = await imageCdnApi.findByPath('misc')
   const [horizontalLogo, aboutPortrait] = ['horizontal', 'portrait'].map(
     (substring) => {
       const image = images.find((image) => image.src.includes(substring))

--- a/scripts/src/projects-content.ts
+++ b/scripts/src/projects-content.ts
@@ -62,7 +62,7 @@ const expandCmsProject = async (
   Log.info('Expanding project "%s"', cmsProject.slug)
   const projectImageDirectory = `${PROJECTS_DIR}/${cmsProject.slug}`
   const previewImages = await toSignedResponsiveImages(
-    await imageCdnApi.getAllImagesInPath(
+    await imageCdnApi.findByPath(
       `${projectImageDirectory}/${PREVIEW_PRESET_JSON.slug}`,
     ),
     PROJECT_LIST_ITEM,
@@ -84,10 +84,7 @@ const expandCmsProject = async (
         const albumImageDirectory = cmsProjectAlbum.subdirectory
           ? `${albumPresetImageDirectory}/${cmsProjectAlbum.subdirectory}`
           : albumPresetImageDirectory
-        const images = await imageCdnApi.getAllImagesInPath(
-          albumImageDirectory,
-          false,
-        )
+        const images = await imageCdnApi.findByPath(albumImageDirectory)
         const albumsWithSamePreset = (cmsProject.albums ?? []).filter(
           (album) => album.presetSlug === cmsProjectAlbum.presetSlug,
         )


### PR DESCRIPTION
After reviewing `ImageCdnApi` interface in last PR: 
 - `Image` is not needed in `signImage`, just the path of that image. So providing just this to favour interface segregation principle (ISP)
 - `signImage` isn't actually accurate. It provides the signature for the delivery URL. Renaming to make that more explicit
 - Reducing name of `getAllImagesInPath`. `Images` is redundant in an `ImageCdnApi` kind of thing. Replacing `getAll` by `findBy`. More Spring'y. I like it :P
 - Remove param to look for images in subdirs. That doesn't exist anymore.
