### PR TITLE
test: add source size models string tests

### DIFF
--- a/scripts/src/images/models/source-size-list.test.ts
+++ b/scripts/src/images/models/source-size-list.test.ts
@@ -1,0 +1,18 @@
+import { describe, it } from 'node:test'
+import { strictEqual } from 'node:assert'
+import { sourceSizeList } from './source-size-list'
+import { SourceSize } from './source-size'
+
+describe('Source size list', () => {
+  const SOURCE_SIZE_LIST = sourceSizeList(
+    { toString: () => 'sourceSizeA', mediaCondition: {} } as SourceSize,
+    { toString: () => 'sourceSizeB' } as SourceSize,
+  )
+
+  it('should join sizes by comma when representing it as a string', () => {
+    strictEqual(
+      SOURCE_SIZE_LIST.toString(),
+      `${SOURCE_SIZE_LIST.sizes[0].toString()},${SOURCE_SIZE_LIST.sizes[1].toString()}`,
+    )
+  })
+})

--- a/scripts/src/images/models/source-size.test.ts
+++ b/scripts/src/images/models/source-size.test.ts
@@ -1,0 +1,25 @@
+import { describe, it } from 'node:test'
+import { strictEqual } from 'node:assert'
+import { sourceSize } from './source-size'
+import { Px, Vw } from './css-length'
+import { CssPxLimitMediaCondition } from './css-media-condition'
+
+describe('Source size', () => {
+  const sut = sourceSize
+
+  it('should print its length as a calc CSS function when length is an array', () => {
+    strictEqual(
+      sut([Px(100), Vw(50), Px(-16)]).toString(),
+      'calc(100px + 50vw - 16px)',
+    )
+  })
+
+  it('should print the media condition', () => {
+    strictEqual(
+      sut(Px(100), {
+        toString: () => 'mediaCondition',
+      } as CssPxLimitMediaCondition).toString(),
+      'mediaCondition 100px',
+    )
+  })
+})


### PR DESCRIPTION
Whilst coding representations to model a `sizes` attribute so it can be used for the breakpoints generation algorithm, the `toString` of some of them failed few times. To ensure future code changes don't break `sizes` strings representations, adding few tests in there
