### PR TITLE
refactor: rename CDN API files to be distinguished

### DIFF
--- a/scripts/src/images/cdn/apis/cloudinary-cdn-api.ts
+++ b/scripts/src/images/cdn/apis/cloudinary-cdn-api.ts
@@ -21,10 +21,10 @@ import {
 } from '../../../utils/json'
 import { join } from 'path'
 
-export class Cloudinary implements ImageCdnApi {
+export class CloudinaryCdnApi implements ImageCdnApi {
   private static _sdkOptions: ConfigOptions
 
-  static async getInstance(): Promise<Cloudinary> {
+  static async getInstance(): Promise<CloudinaryCdnApi> {
     if (!this._sdkOptions) {
       // Read from env
       dotenv.config()
@@ -61,7 +61,7 @@ export class Cloudinary implements ImageCdnApi {
       cloudinary.config(this._sdkOptions)
     }
 
-    return new Cloudinary()
+    return new CloudinaryCdnApi()
   }
 
   async findByPath(path: string): Promise<readonly Image[]> {

--- a/scripts/src/images/cdn/apis/imagekit-cdn-api.ts
+++ b/scripts/src/images/cdn/apis/imagekit-cdn-api.ts
@@ -17,14 +17,14 @@ import { URLSearchParams } from 'url'
 import { CLOUD_URL, urlForBreakpoint } from '@/app/common/images/cdn/imagekit'
 import { getSignature } from 'imagekit/dist/libs/url/builder'
 
-export class Imagekit implements ImageCdnApi {
+export class ImagekitCdnApi implements ImageCdnApi {
   private readonly _sdk: ImagekitSdk
 
   constructor(sdkOptions: ImageKitOptions) {
     this._sdk = new ImageKit(sdkOptions)
   }
 
-  static getInstance(): Imagekit {
+  static getInstance(): ImagekitCdnApi {
     dotenv.config()
 
     const { IMAGEKIT_PUBLIC_KEY, IMAGEKIT_PRIVATE_KEY } = process.env
@@ -36,7 +36,7 @@ export class Imagekit implements ImageCdnApi {
       process.exit(1)
     }
 
-    return new Imagekit({
+    return new ImagekitCdnApi({
       urlEndpoint: CLOUD_URL,
       publicKey: IMAGEKIT_PUBLIC_KEY,
       privateKey: IMAGEKIT_PRIVATE_KEY,

--- a/scripts/src/images/cdn/index.ts
+++ b/scripts/src/images/cdn/index.ts
@@ -1,15 +1,15 @@
 // 👇 Needs to be here, first line.
 //    Because of image CDN config exporting Angular providers
 import '@angular/compiler'
-import { Cloudinary } from './apis/cloudinary'
-import { Imagekit } from './apis/imagekit'
+import { CloudinaryCdnApi } from './apis/cloudinary-cdn-api'
+import { ImagekitCdnApi } from './apis/imagekit-cdn-api'
 import { CDN_NAME, CdnNames } from '@/app/common/images/cdn'
 import { Log } from '../../utils/log'
 import type { ImageCdnApi } from './image-cdn-api'
 
 const CDN_APIS_BY_NAME: Record<CdnNames, () => Promise<ImageCdnApi>> = {
-  imagekit: async () => Imagekit.getInstance(),
-  cloudinary: Cloudinary.getInstance,
+  imagekit: async () => ImagekitCdnApi.getInstance(),
+  cloudinary: CloudinaryCdnApi.getInstance,
 }
 export const getImageCdnApi = (): Promise<ImageCdnApi> => {
   Log.info(`Using ${CDN_NAME} as image CDN`)

--- a/scripts/src/images/responsive/breakpoints.ts
+++ b/scripts/src/images/responsive/breakpoints.ts
@@ -2,7 +2,7 @@ import { Breakpoints, Image } from '@/app/common/images/image'
 import { SourceSizeList } from '../models/source-size-list'
 import { CDN_NAME } from '@/app/common/images/cdn'
 import { CDN_NAME as CLOUDINARY_CDN_NAME } from '@/app/common/images/cdn/cloudinary'
-import { Cloudinary } from '../cdn/apis/cloudinary'
+import { CloudinaryCdnApi } from '../cdn/apis/cloudinary-cdn-api'
 import { breakpointsFromSizesAndDimensions } from './breakpoints-from-sizes-and-dimensions'
 
 export type BreakpointsFn = (
@@ -21,8 +21,8 @@ export const getBreakpointsFn = async (): Promise<BreakpointsFn> => {
 
 const getCloudinaryResponsiveBreakpointsApi =
   async (): Promise<BreakpointsFn> => {
-    const cloudinaryApi = await Cloudinary.getInstance()
-    return cloudinaryApi.breakpointsForImage.bind(cloudinaryApi)
+    const cloudinaryCdnApi = await CloudinaryCdnApi.getInstance()
+    return cloudinaryCdnApi.breakpointsForImage.bind(cloudinaryCdnApi)
   }
 
 const getBreakpointsFromSizesAndDimensionsApi =


### PR DESCRIPTION
When looking for a file to open, both app and scripts have an `imagekit` and a `cloudinary` file. Distinguishing them requires looking at its path. To make it a bit faster to distinguish, renaming them so that it's clear at a glance which is which.
