### PR TITLE
perf: use fixed breakpoints strategy for logo

### DIFF
--- a/lighthouserc.cjs
+++ b/lighthouserc.cjs
@@ -19,7 +19,7 @@ module.exports = {
           matchingUrlPattern: '.*',
           preset: 'lighthouse:no-pwa',
           assertions: {
-            'uses-responsive-images': ['error', { maxLength: 2 }],
+            'uses-responsive-images': ['error', { maxLength: 1 }],
           },
         },
         // Non-project detail

--- a/scripts/src/images/responsive/breakpoints-from-sizes-and-dimensions.ts
+++ b/scripts/src/images/responsive/breakpoints-from-sizes-and-dimensions.ts
@@ -119,7 +119,7 @@ const RESOLUTION_WIDTHS = Array.from(
   new Set([...DEFAULT_RESOLUTIONS, ...MOBILE_RESOLUTION_WIDTHS]),
 ).sort((a, b) => a - b)
 
-const getHighDensityBreakpoints = (
+export const getHighDensityBreakpoints = (
   pxWidth: number,
   maxPxWidth: number,
 ): readonly number[] => {

--- a/scripts/src/images/sizes.ts
+++ b/scripts/src/images/sizes.ts
@@ -6,6 +6,7 @@ import { BREAKPOINT_S_PX, BREAKPOINT_XS_PX } from '@/app/common/breakpoints'
 import { ProjectDetailAlbum } from '@/app/projects/project'
 import { PROJECT_DETAIL_PAGE_SWIPER_FULL } from '@/app/projects/project-detail-page/project-detail-page-swipers'
 import { HORIZONTAL_PAGE_PADDING_PX } from '@/app/common/paddings'
+import { ImageDimensions } from './responsive/breakpoints-from-sizes-and-dimensions'
 
 const horizontalPagePadding = (divider = 1) =>
   Px(HORIZONTAL_PAGE_PADDING_PX / divider)
@@ -32,19 +33,19 @@ export const ABOUT = sourceSizeList(
 )
 
 // TODO: could be just one asset indeed (for max-height + multiple densities)
+const LOGO_DIMENSIONS: ImageDimensions = { width: 2757, height: 409 }
+// Keep in sync with SCSS
+const LOGO_MAX_HEIGHT_PX = 55
+export const LOGO_MAX_WIDTH_PX = Math.ceil(
+  (LOGO_MAX_HEIGHT_PX * LOGO_DIMENSIONS.width) / LOGO_DIMENSIONS.height,
+)
 export const LOGO = (() => {
-  const LOGO_ASPECT_RATIO = { width: 2757, height: 409 }
-  // Keep in sync with SCSS
-  const MAX_HEIGHT_PX = 55
-  const MAX_WIDTH_PX = Math.ceil(
-    (MAX_HEIGHT_PX * LOGO_ASPECT_RATIO.width) / LOGO_ASPECT_RATIO.height,
-  )
   return sourceSizeList(
     sourceSize(
       withoutHorizontalPagePadding(Vw(100)),
-      maxWidth(MAX_WIDTH_PX + HORIZONTAL_PAGE_PADDING_PX),
+      maxWidth(LOGO_MAX_WIDTH_PX + HORIZONTAL_PAGE_PADDING_PX),
     ),
-    sourceSize(Px(MAX_WIDTH_PX)),
+    sourceSize(Px(LOGO_MAX_WIDTH_PX)),
   )
 })()
 

--- a/scripts/src/misc-images.ts
+++ b/scripts/src/misc-images.ts
@@ -6,8 +6,10 @@ import { GENERATED_DATA_PATH } from './utils/paths'
 import { join } from 'path'
 import { mkdir } from 'fs/promises'
 import { getImageCdnApi } from './images/cdn'
-import { ABOUT, LOGO } from './images/sizes'
+import { ABOUT, LOGO, LOGO_MAX_WIDTH_PX } from './images/sizes'
 import { toSignedResponsiveImage } from './images/responsive/to-signed-responsive-image'
+import { signResponsiveImage } from './images/responsive/sign-responsive-image'
+import { getHighDensityBreakpoints } from './images/responsive/breakpoints-from-sizes-and-dimensions'
 
 export const miscImages = async (): Promise<void> => {
   const imageCdnApi = await getImageCdnApi()
@@ -24,9 +26,15 @@ export const miscImages = async (): Promise<void> => {
     },
   )
   const miscImages: MiscImages = {
-    horizontalLogo: await toSignedResponsiveImage(
-      horizontalLogo,
-      LOGO,
+    horizontalLogo: await signResponsiveImage(
+      {
+        ...horizontalLogo,
+        breakpoints: getHighDensityBreakpoints(
+          LOGO_MAX_WIDTH_PX,
+          horizontalLogo.width,
+        ),
+        sizes: LOGO.toString(),
+      },
       imageCdnApi,
     ),
     aboutPortrait: await toSignedResponsiveImage(


### PR DESCRIPTION
Given it will be fixed at size 55px height / 371px width. Or less if viewport is narrower. At that fixed size, image weights 6kBs. For this one, generating based on a performance budget is not needed. Generating an image for the only resolution lower than this one (360) doesn't provide enough benefit given is very lightweight. So generating only high density breakpoints for high res screens and moving on.

After this change, making a bit stricter the responsive images audit assertion in Lighthouse. As now the logo picture is properly sized