### PR TITLE
refactor: don't prefix :host to CSS classes if unneeded

### DIFF
--- a/src/app/about-page/about-page.component.scss
+++ b/src/app/about-page/about-page.component.scss
@@ -2,7 +2,6 @@
 @use 'page';
 @use 'typographies';
 @use 'margins';
-@use 'content';
 
 :host {
   display: flex;
@@ -10,42 +9,42 @@
   @include page.padding;
   gap: margins.$m;
   align-items: center;
+}
 
-  .links {
-    display: flex;
-    flex-wrap: wrap;
-    gap: margins.$m;
-    place-content: center;
-    align-items: center;
+.links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: margins.$m;
+  place-content: center;
+  align-items: center;
+}
+
+h1 {
+  @include typographies.size(7);
+  @include typographies.bold;
+}
+
+/** 👇 Keep in sync with component responsive image breakpoints **/
+article {
+  display: flex;
+  flex-direction: column;
+  gap: margins.$m;
+  max-width: 35vw;
+
+  @include breakpoints.s {
+    max-width: 60vw;
   }
 
-  h1 {
-    @include typographies.size(7);
-    @include typographies.bold;
+  @include breakpoints.xs {
+    max-width: 75vw;
   }
+}
 
-  /** 👇 Keep in sync with component responsive image breakpoints **/
-  article {
-    display: flex;
-    flex-direction: column;
-    gap: margins.$m;
-    max-width: 35vw;
+p {
+  white-space: pre-wrap;
+}
 
-    @include breakpoints.s {
-      max-width: 60vw;
-    }
-
-    @include breakpoints.xs {
-      max-width: 75vw;
-    }
-  }
-
-  p {
-    white-space: pre-wrap;
-  }
-
-  img {
-    object-fit: contain;
-    object-position: top;
-  }
+img {
+  object-fit: contain;
+  object-position: top;
 }

--- a/src/app/about-page/resume/resume.component.scss
+++ b/src/app/about-page/resume/resume.component.scss
@@ -1,14 +1,12 @@
 @use 'margins';
 
-:host {
-  ul {
-    display: flex;
-    gap: margins.$m;
-  }
+ul {
+  display: flex;
+  gap: margins.$m;
+}
 
-  fa-icon {
-    display: inline-block;
-    font-size: 1em;
-    height: 1em;
-  }
+fa-icon {
+  display: inline-block;
+  font-size: 1em;
+  height: 1em;
 }

--- a/src/app/about-page/social/social.component.scss
+++ b/src/app/about-page/social/social.component.scss
@@ -1,18 +1,16 @@
 @use 'margins';
 
-:host {
-  ul {
-    display: flex;
-    flex-direction: row;
-    gap: margins.$m;
-  }
+ul {
+  display: flex;
+  flex-direction: row;
+  gap: margins.$m;
+}
 
-  li {
-    height: 32px;
+li {
+  height: 32px;
 
-    fa-icon {
-      // To take 32px height
-      font-size: 26.5px;
-    }
+  fa-icon {
+    // To take 32px height
+    font-size: 26.5px;
   }
 }

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -5,16 +5,16 @@
 
 :host {
   background-color: white;
+}
 
-  header {
-    @include typographies.regular;
-    padding: header.$padding-vertical page.$padding-horizontal;
-    justify-content: center;
-    font-size: header.$font-size;
+header {
+  @include typographies.regular;
+  padding: header.$padding-vertical page.$padding-horizontal;
+  justify-content: center;
+  font-size: header.$font-size;
 
-    ul {
-      display: flex;
-      justify-content: space-evenly;
-    }
+  ul {
+    display: flex;
+    justify-content: space-evenly;
   }
 }

--- a/src/app/logo/logo.component.scss
+++ b/src/app/logo/logo.component.scss
@@ -17,10 +17,10 @@
   justify-content: center;
 
   padding: logo.$padding-vertical page.$padding-horizontal;
+}
 
-  img {
-    // Keep in sync with component for responsive sizing!
-    max-height: logo.$height-image;
-    width: auto;
-  }
+img {
+  // Keep in sync with component for responsive sizing!
+  max-height: logo.$height-image;
+  width: auto;
 }

--- a/src/app/not-found-page/not-found-page.component.scss
+++ b/src/app/not-found-page/not-found-page.component.scss
@@ -8,15 +8,15 @@
   flex-direction: column;
   place-content: center;
   text-align: center;
+}
 
-  .sad-face {
-    @include typographies.size(10);
-    @include typographies.bold;
-    margin-bottom: margins.$m;
-  }
+.sad-face {
+  @include typographies.size(10);
+  @include typographies.bold;
+  margin-bottom: margins.$m;
+}
 
-  h2 {
-    @include typographies.size(8);
-    @include typographies.bold;
-  }
+h2 {
+  @include typographies.size(8);
+  @include typographies.bold;
 }

--- a/src/app/projects/images-swiper/images-swiper.component.scss
+++ b/src/app/projects/images-swiper/images-swiper.component.scss
@@ -1,32 +1,30 @@
 @use 'theme';
 
-:host {
-  swiper-container {
-    width: 100%;
-    height: 100%;
-    overflow: hidden;
-    display: flex;
+swiper-container {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  display: flex;
 
-    swiper-slide {
-      position: relative;
-      max-height: inherit;
+  swiper-slide {
+    position: relative;
+    max-height: inherit;
 
-      img {
-        object-fit: contain;
-      }
+    img {
+      object-fit: contain;
     }
   }
+}
 
-  $balanced-luminance-color: theme.$accent;
+$balanced-luminance-color: theme.$accent;
 
-  swiper-container::part(button-prev),
-  swiper-container::part(button-next) {
-    position: absolute; // perf trick 2 avoid layout shifts
-    color: $balanced-luminance-color;
-  }
+swiper-container::part(button-prev),
+swiper-container::part(button-next) {
+  position: absolute; // perf trick 2 avoid layout shifts
+  color: $balanced-luminance-color;
+}
 
-  swiper-container::part(bullet-active),
-  swiper-container::part(bullet) {
-    background-color: $balanced-luminance-color;
-  }
+swiper-container::part(bullet-active),
+swiper-container::part(bullet) {
+  background-color: $balanced-luminance-color;
 }

--- a/src/app/projects/project-detail-page/project-detail-page.component.scss
+++ b/src/app/projects/project-detail-page/project-detail-page.component.scss
@@ -8,36 +8,36 @@
   @include page.padding;
   gap: margins.$m;
   justify-content: center;
+}
 
-  h2 {
-    text-align: center;
-  }
+h2 {
+  text-align: center;
+}
 
-  $assetsGap: margins.$m;
+$assetsGap: margins.$m;
 
-  //👇 Keep in sync with component responsive images
-  .assets {
-    display: flex;
-    flex-direction: column;
-    gap: $assetsGap;
-    align-items: center;
+//👇 Keep in sync with component responsive images
+.assets {
+  display: flex;
+  flex-direction: column;
+  gap: $assetsGap;
+  align-items: center;
+  width: 100%;
+
+  > app-images-swiper {
     width: 100%;
-
-    > app-images-swiper {
-      width: 100%;
-      //ℹ️ max-width set by component for big screens
-    }
-
-    iframe {
-      max-width: 100%;
-    }
+    //ℹ️ max-width set by component for big screens
   }
 
-  .half {
-    width: calc(50% - $assetsGap);
+  iframe {
+    max-width: 100%;
+  }
+}
 
-    @include breakpoints.until-s {
-      width: 100%;
-    }
+.half {
+  width: calc(50% - $assetsGap);
+
+  @include breakpoints.until-s {
+    width: 100%;
   }
 }

--- a/src/app/projects/projects-list-page/project-list-item/project-list-item.component.scss
+++ b/src/app/projects/projects-list-page/project-list-item/project-list-item.component.scss
@@ -9,91 +9,91 @@
   display: flex;
   flex-direction: column;
   gap: margins.$m;
+}
 
+.text-and-images {
+  display: flex;
+  align-content: flex-start;
+  gap: margins.$l;
+}
+
+$texts-width-big-screen: 55ch;
+
+.texts {
+  display: flex;
+  flex-direction: column;
+  max-width: 55ch;
+}
+
+//👇 Keep in sync with component responsive images
+app-images-swiper {
+  // 👇 Seems swiper needs size set to work fine
+  $page-padding-horizontal: page.$padding-horizontal;
+  width: calc(100vw - $texts-width-big-screen - $page-padding-horizontal * 2);
+  $extra-space: 48px;
+  $available-height: content.$available-height;
+  max-height: calc($available-height);
+}
+
+@include breakpoints.until-s {
   .text-and-images {
-    display: flex;
-    align-content: flex-start;
-    gap: margins.$l;
+    flex-wrap: wrap;
+    gap: margins.$m;
   }
-
-  $texts-width-big-screen: 55ch;
 
   .texts {
-    display: flex;
-    flex-direction: column;
-    max-width: 55ch;
+    order: 2;
+    max-width: unset;
   }
 
-  //👇 Keep in sync with component responsive images
   app-images-swiper {
-    // 👇 Seems swiper needs size set to work fine
-    $page-padding-horizontal: page.$padding-horizontal;
-    width: calc(100vw - $texts-width-big-screen - $page-padding-horizontal * 2);
-    $extra-space: 48px;
-    $available-height: content.$available-height;
-    max-height: calc($available-height);
+    width: 100%;
+    min-height: 300px;
+    order: 1;
+
+    $extra-space: 128px;
+    $available-height: content.$available-height-with-header;
+    max-height: calc($available-height - $extra-space);
   }
+}
 
-  @include breakpoints.until-s {
-    .text-and-images {
-      flex-wrap: wrap;
-      gap: margins.$m;
-    }
+.title {
+  @include typographies.size(8);
+  @include typographies.bold;
 
-    .texts {
-      order: 2;
-      max-width: unset;
-    }
+  margin-bottom: margins.$xxs;
+}
 
-    app-images-swiper {
-      width: 100%;
-      min-height: 300px;
-      order: 1;
+.subtitle {
+  @include typographies.size(4);
+  @include typographies.bold;
 
-      $extra-space: 128px;
-      $available-height: content.$available-height-with-header;
-      max-height: calc($available-height - $extra-space);
-    }
-  }
+  margin-bottom: margins.$l;
+}
 
-  .title {
-    @include typographies.size(8);
-    @include typographies.bold;
+.quote {
+  @include typographies.size(1);
+  @include typographies.regular;
 
-    margin-bottom: margins.$xxs;
-  }
+  margin-bottom: margins.$l;
+}
 
-  .subtitle {
-    @include typographies.size(4);
-    @include typographies.bold;
+.description {
+  @include typographies.light;
 
-    margin-bottom: margins.$l;
-  }
+  // Keep line breaks
+  white-space: pre-wrap;
+}
 
-  .quote {
-    @include typographies.size(1);
-    @include typographies.regular;
+.credits {
+  @include typographies.regular;
 
-    margin-bottom: margins.$l;
-  }
+  display: flex;
+  flex-wrap: wrap;
+  gap: margins.$s;
+  justify-content: flex-start;
 
-  .description {
-    @include typographies.light;
-
-    // Keep line breaks
-    white-space: pre-wrap;
-  }
-
-  .credits {
-    @include typographies.regular;
-
-    display: flex;
-    flex-wrap: wrap;
-    gap: margins.$s;
-    justify-content: flex-start;
-
-    .anchor {
-      display: inline-block;
-    }
+  .anchor {
+    display: inline-block;
   }
 }

--- a/src/app/projects/projects-list-page/projects-list-page.component.scss
+++ b/src/app/projects/projects-list-page/projects-list-page.component.scss
@@ -8,13 +8,13 @@
   flex-direction: row;
   flex-wrap: wrap;
   gap: margins.$l;
+}
 
-  app-project-list-item {
-    flex: 1;
+app-project-list-item {
+  flex: 1;
 
-    &.has-preview-images {
-      flex: unset;
-      max-width: 100%;
-    }
+  &.has-preview-images {
+    flex: unset;
+    max-width: 100%;
   }
 }


### PR DESCRIPTION
Title speaks by itself :P If using [default view encapsulation](https://angular.dev/guide/components/styling#style-scoping) styles will only apply to current component. So no need to add `:host` prefix around. This will reduce a bit the CSS code.
