### PR TITLE
feat: small 404 page improvements

### DIFF
--- a/data/cms/pages/404.json
+++ b/data/cms/pages/404.json
@@ -1,6 +1,6 @@
 {
-  "name": "Not Found",
+  "name": "Not found",
   "slug": "404",
-  "title": "Not Found",
+  "title": "Not found",
   "description": "The requested content could not be found"
 }

--- a/src/app/not-found-page/not-found-page.component.html
+++ b/src/app/not-found-page/not-found-page.component.html
@@ -1,3 +1,3 @@
 <span class="sad-face">(◡︵◡)</span>
-<h2>Error 404</h2>
+<h1>{{ title }}</h1>
 <p>{{ description }}</p>

--- a/src/app/not-found-page/not-found-page.component.scss
+++ b/src/app/not-found-page/not-found-page.component.scss
@@ -16,7 +16,7 @@
   margin-bottom: margins.$m;
 }
 
-h2 {
+h1 {
   @include typographies.size(8);
   @include typographies.bold;
 }

--- a/src/app/not-found-page/not-found-page.component.ts
+++ b/src/app/not-found-page/not-found-page.component.ts
@@ -7,5 +7,6 @@ import notFoundPageMetadata from '@/data/cms/pages/404.json'
   standalone: true,
 })
 export class NotFoundPageComponent {
-  readonly description: string = notFoundPageMetadata.description
+  readonly title = notFoundPageMetadata.title
+  readonly description = notFoundPageMetadata.description
 }


### PR DESCRIPTION
Turn `h2` into an `h1`. No sense to have an `h2` with no `h1`.

Detitlize page title

Use page title in contents
