### PR TITLE
refactor: improve logo sizes / max height handling

### DIFF
--- a/scripts/src/images/responsive/breakpoints-from-sizes-and-dimensions.test.ts
+++ b/scripts/src/images/responsive/breakpoints-from-sizes-and-dimensions.test.ts
@@ -2,7 +2,6 @@ import { describe, it } from 'node:test'
 import { SourceSizeList } from '../models/source-size-list'
 import {
   breakpointsFromSizesAndDimensions,
-  ImageDimensions,
   MOBILE_RESOLUTION_WIDTHS,
 } from './breakpoints-from-sizes-and-dimensions'
 import { sourceSize } from '../models/source-size'
@@ -10,6 +9,7 @@ import { Px, Vw } from '../models/css-length'
 import assert from 'node:assert'
 import * as SIZES_IMPORT from '../sizes'
 import { PROJECT_DETAIL_BY_PRESET_SIZE } from '../sizes'
+import { ImageDimensions } from '@/app/common/images/image'
 
 describe('Breakpoints from sizes and dimensions', () => {
   const SAMPLE_IMAGE_DIMENSIONS: ImageDimensions = {

--- a/scripts/src/images/responsive/breakpoints-from-sizes-and-dimensions.test.ts.snapshot
+++ b/scripts/src/images/responsive/breakpoints-from-sizes-and-dimensions.test.ts.snapshot
@@ -25,17 +25,6 @@ exports[`Breakpoints from sizes and dimensions > should return expected breakpoi
 ]
 `;
 
-exports[`Breakpoints from sizes and dimensions > should return expected breakpoints snapshot for LOGO 1`] = `
-[
-  328,
-  371,
-  656,
-  742,
-  984,
-  1113
-]
-`;
-
 exports[`Breakpoints from sizes and dimensions > should return expected breakpoints snapshot for PROJECT_DETAIL_FULL 1`] = `
 [
   164,

--- a/scripts/src/images/responsive/breakpoints-from-sizes-and-dimensions.ts
+++ b/scripts/src/images/responsive/breakpoints-from-sizes-and-dimensions.ts
@@ -1,5 +1,5 @@
 import { SourceSizeList } from '../models/source-size-list'
-import { Breakpoints, Image } from '@/app/common/images/image'
+import { Breakpoints, ImageDimensions } from '@/app/common/images/image'
 import { SourceSize } from '../models/source-size'
 import { MAX_LIMIT, MIN_LIMIT } from '../models/css-media-condition'
 import { CSS_PX_UNIT, CSS_VW_UNIT, CssLength } from '../models/css-length'
@@ -51,11 +51,6 @@ export const breakpointsFromSizesAndDimensions = (
     ),
     estimateMaxPxBetweenBreakpoints(imageDimensions),
   )
-
-export interface ImageDimensions {
-  readonly width: number
-  readonly height: number
-}
 
 interface BreakpointsAndResolutionWidths {
   readonly breakpoints: readonly number[]
@@ -164,17 +159,14 @@ const reduceBreakpoints = (
   return reducedBreakpoints
 }
 
-const estimateMaxPxBetweenBreakpoints = (
-  aspectRatio: Pick<Image, 'width' | 'height'>,
-) => {
+const estimateMaxPxBetweenBreakpoints = (dimensions: ImageDimensions) => {
   // Amount of bytes each pixel takes at a true color bit depth
   const PX_SIZE_BYTES = 3
   const COMPRESSION_RATIO = 0.5
   const LIGHTHOUSE_PX_THRESHOLD =
     LIGHTHOUSE_BYTES_THRESHOLD / (PX_SIZE_BYTES * COMPRESSION_RATIO)
   return Math.floor(
-    Math.sqrt(LIGHTHOUSE_PX_THRESHOLD) *
-      (aspectRatio.height / aspectRatio.width),
+    Math.sqrt(LIGHTHOUSE_PX_THRESHOLD) * (dimensions.height / dimensions.width),
   )
 }
 

--- a/scripts/src/images/sizes.ts
+++ b/scripts/src/images/sizes.ts
@@ -9,7 +9,6 @@ import {
 } from '@/app/projects/project'
 import { PROJECT_DETAIL_PAGE_SWIPER_FULL } from '@/app/projects/project-detail-page/project-detail-page-swipers'
 import { HORIZONTAL_PAGE_PADDING_PX } from '@/app/common/paddings'
-import { ImageDimensions } from './responsive/breakpoints-from-sizes-and-dimensions'
 
 const horizontalPagePadding = (divider = 1) =>
   Px(HORIZONTAL_PAGE_PADDING_PX / divider)
@@ -35,22 +34,15 @@ export const ABOUT = sourceSizeList(
   sourceSize(withoutHorizontalPagePadding(Vw(75))),
 )
 
-// TODO: could be just one asset indeed (for max-height + multiple densities)
-const LOGO_DIMENSIONS: ImageDimensions = { width: 2757, height: 409 }
-// Keep in sync with SCSS
-const LOGO_MAX_HEIGHT_PX = 55
-export const LOGO_MAX_WIDTH_PX = Math.ceil(
-  (LOGO_MAX_HEIGHT_PX * LOGO_DIMENSIONS.width) / LOGO_DIMENSIONS.height,
-)
-export const LOGO = (() => {
+export const logoSizesFromMaxWidth = (maxWidthPx: number) => {
   return sourceSizeList(
     sourceSize(
       withoutHorizontalPagePadding(Vw(100)),
-      maxWidth(LOGO_MAX_WIDTH_PX + HORIZONTAL_PAGE_PADDING_PX),
+      maxWidth(maxWidthPx + HORIZONTAL_PAGE_PADDING_PX),
     ),
-    sourceSize(Px(LOGO_MAX_WIDTH_PX)),
+    sourceSize(Px(maxWidthPx)),
   )
-})()
+}
 
 export const PROJECT_LIST_ITEM = (() => {
   const SLIDES_PER_VIEW = PROJECT_LIST_ITEM_SLIDES_PER_VIEW

--- a/scripts/src/misc-images.ts
+++ b/scripts/src/misc-images.ts
@@ -6,10 +6,11 @@ import { GENERATED_DATA_PATH } from './utils/paths'
 import { join } from 'path'
 import { mkdir } from 'fs/promises'
 import { getImageCdnApi } from './images/cdn'
-import { ABOUT, LOGO, LOGO_MAX_WIDTH_PX } from './images/sizes'
+import { ABOUT, logoSizesFromMaxWidth } from './images/sizes'
 import { toSignedResponsiveImage } from './images/responsive/to-signed-responsive-image'
 import { signResponsiveImage } from './images/responsive/sign-responsive-image'
 import { getHighDensityBreakpoints } from './images/responsive/breakpoints-from-sizes-and-dimensions'
+import { getLogoMaxWidthFromDimensions } from '@/app/logo/logo'
 
 export const miscImages = async (): Promise<void> => {
   const imageCdnApi = await getImageCdnApi()
@@ -25,15 +26,16 @@ export const miscImages = async (): Promise<void> => {
       return image
     },
   )
+  const logoMaxWidth = getLogoMaxWidthFromDimensions(horizontalLogo)
   const miscImages: MiscImages = {
     horizontalLogo: await signResponsiveImage(
       {
         ...horizontalLogo,
         breakpoints: getHighDensityBreakpoints(
-          LOGO_MAX_WIDTH_PX,
+          logoMaxWidth,
           horizontalLogo.width,
         ),
-        sizes: LOGO.toString(),
+        sizes: logoSizesFromMaxWidth(logoMaxWidth).toString(),
       },
       imageCdnApi,
     ),

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -23,6 +23,7 @@
     "../src/app/common/images/cdn/**/*.ts",
     "../src/app/common/images/image.ts",
     "../src/app/common/images/misc-images.ts",
+    "../src/app/logo/logo.ts",
     "../src/app/projects/project.ts",
     "../src/app/projects/project-detail-page/project-detail-page-swipers.ts",
     "../data/**/*.json"

--- a/src/app/common/images/image.ts
+++ b/src/app/common/images/image.ts
@@ -1,10 +1,13 @@
 import { ImageLoaderConfig } from '@angular/common'
 
-export interface Image {
-  src: string
-  width: number
-  height: number
-  alt?: string
+export interface ImageDimensions {
+  readonly width: number
+  readonly height: number
+}
+
+export type Image = ImageDimensions & {
+  readonly src: string
+  readonly alt?: string
 }
 
 export type ResponsiveImage = Image & {

--- a/src/app/logo/logo.component.scss
+++ b/src/app/logo/logo.component.scss
@@ -20,7 +20,6 @@
 }
 
 img {
-  // Keep in sync with component for responsive sizing!
   max-height: logo.$height-image;
   width: auto;
 }

--- a/src/app/logo/logo.ts
+++ b/src/app/logo/logo.ts
@@ -1,0 +1,8 @@
+// Keep in sync with SCSS content styles
+import { ImageDimensions } from '@/app/common/images/image'
+
+export const LOGO_MAX_HEIGHT_PX = 55
+export const getLogoMaxWidthFromDimensions = ({
+  width,
+  height,
+}: ImageDimensions) => Math.ceil((LOGO_MAX_HEIGHT_PX * width) / height)


### PR DESCRIPTION
Review and improve how logo sizes and max height was applied:
 - `sizes` comes from logo dimensions. Which is known after looking for it in image CDN. So make it a function instead of hardcoding current logo dimensions
 - No need to keep in sync the logo component SCSS. It's the `_logo.scss` the one to keep in sync. Remove the comment
 - Calculate max logo in a shared place. Use its as input its image dimensions. 
Extra
 - Move `ImageDimensions` to be part of app model. So both app and scripts can use it. Eventually just scripts are using it for now. But feels a better place than breakpoints file in scripts.
