### PR TITLE
refactor: simplify images swiper

### DIFF
--- a/src/app/projects/images-swiper/images-swiper.component.html
+++ b/src/app/projects/images-swiper/images-swiper.component.html
@@ -20,7 +20,7 @@
         <img
           [ngSrc]="image.src"
           [ngSrcset]="image.breakpoints | toNgSrcSet"
-          [sizes]="image.sizes || sizes()"
+          [sizes]="sizes()"
           [fill]="true"
           [priority]="priority() && i < (maxSlidesPerView ?? 0)"
           [alt]="image.alt || 'Image'"

--- a/src/app/projects/images-swiper/images-swiper.component.html
+++ b/src/app/projects/images-swiper/images-swiper.component.html
@@ -1,28 +1,23 @@
 @if (images().length) {
   @let firstImage = images()[0];
-  @let maxSlidesPerView = _maxSlidesPerView();
   <swiper-container
-    [appSwiper]="_effectiveSwiperOptions()"
+    [appSwiper]="_swiperOptions()"
     init="false"
     [style.aspect-ratio]="
-      maxSlidesPerView
-        ? (maxSlidesPerView * firstImage.width) / firstImage.height
-        : undefined
+      (slidesPerView() * firstImage.width) / firstImage.height
     "
   >
     @for (image of images(); track image; let i = $index) {
       <swiper-slide
         [style.aspect-ratio]="image.width / image.height"
-        [style.min-width.%]="
-          maxSlidesPerView ? 100 / maxSlidesPerView : undefined
-        "
+        [style.min-width.%]="100 / slidesPerView()"
       >
         <img
           [ngSrc]="image.src"
           [ngSrcset]="image.breakpoints | toNgSrcSet"
           [sizes]="sizes()"
           [fill]="true"
-          [priority]="priority() && i < (maxSlidesPerView ?? 0)"
+          [priority]="priority() && i < slidesPerView()"
           [alt]="image.alt || 'Image'"
           [loaderParams]="image | toLoaderParams"
         />

--- a/src/app/projects/images-swiper/images-swiper.component.ts
+++ b/src/app/projects/images-swiper/images-swiper.component.ts
@@ -36,7 +36,7 @@ registerSwiper()
 })
 export class ImagesSwiperComponent {
   readonly images = input.required<readonly ResponsiveImage[]>()
-  readonly sizes = input<string>()
+  readonly sizes = input.required<string>()
   readonly priority = input(false)
   readonly customSwiperOptions = input<SwiperOptions>()
   protected readonly _swiperOptions = computed<SwiperOptions>(() => ({

--- a/src/app/projects/images-swiper/images-swiper.component.ts
+++ b/src/app/projects/images-swiper/images-swiper.component.ts
@@ -37,23 +37,12 @@ registerSwiper()
 export class ImagesSwiperComponent {
   readonly images = input.required<readonly ResponsiveImage[]>()
   readonly sizes = input.required<string>()
+  readonly slidesPerView = input.required<number>()
   readonly priority = input(false)
-  readonly customSwiperOptions = input<SwiperOptions>()
   protected readonly _swiperOptions = computed<SwiperOptions>(() => ({
     ...DEFAULT_SWIPER_OPTIONS,
-    ...this.customSwiperOptions(),
+    slidesPerView: this.slidesPerView(),
   }))
-  protected readonly _effectiveSwiperOptions = computed<SwiperOptions>(
-    (): SwiperOptions =>
-      autoLoopOrRewindSwiperOptions(
-        this._swiperOptions(),
-        this._maxSlidesPerView(),
-        this.images().length,
-      ),
-  )
-  protected readonly _maxSlidesPerView = computed<number | undefined>(() =>
-    getMaxSlidesPerView(this._swiperOptions()),
-  )
 }
 
 const DEFAULT_SWIPER_OPTIONS = {
@@ -78,35 +67,3 @@ const DEFAULT_SWIPER_OPTIONS = {
     dynamicBullets: true,
   },
 } satisfies SwiperOptions
-
-const autoLoopOrRewindSwiperOptions = (
-  swiperOptions: SwiperOptions,
-  maxSlidesPerView: number | undefined,
-  imagesCount: number,
-): SwiperOptions => {
-  if (!swiperOptions.loop || !swiperOptions.rewind) {
-    return swiperOptions
-  }
-  const loop =
-    maxSlidesPerView !== undefined && imagesCount > maxSlidesPerView * 2
-  return {
-    ...swiperOptions,
-    loop,
-    rewind: !loop,
-  }
-}
-
-const getMaxSlidesPerView = (swiperOptions: SwiperOptions) => {
-  const breakpointSlidesPerViews = Object.values(
-    swiperOptions.breakpoints ?? {},
-  ).map((options) => options.slidesPerView)
-  const defaultSlidesPerView = swiperOptions.slidesPerView
-  const allSlidesPerView = [
-    ...breakpointSlidesPerViews,
-    defaultSlidesPerView,
-  ].filter(Number.isInteger as (x: unknown) => x is number)
-  if (!allSlidesPerView.length) {
-    return
-  }
-  return Math.max(...allSlidesPerView)
-}

--- a/src/app/projects/project-detail-page/project-detail-page.component.html
+++ b/src/app/projects/project-detail-page/project-detail-page.component.html
@@ -19,7 +19,7 @@
     <app-images-swiper
       [images]="album.images"
       [sizes]="album.imageSizes"
-      [customSwiperOptions]="{ slidesPerView: album.slidesPerView }"
+      [slidesPerView]="album.slidesPerView"
       [style.max-width.px]="album.maxWidthPx"
       [priority]="index < _maxSwipersPerViewport"
     ></app-images-swiper>

--- a/src/app/projects/projects-list-page/project-list-item/project-list-item.component.html
+++ b/src/app/projects/projects-list-page/project-list-item/project-list-item.component.html
@@ -26,7 +26,7 @@
       [images]="previewImages"
       [sizes]="item().previewImageSizes"
       [priority]="priority()"
-      [customSwiperOptions]="{ slidesPerView: _SLIDES_PER_VIEW }"
+      [slidesPerView]="_SLIDES_PER_VIEW"
     ></app-images-swiper>
   }
 </div>


### PR DESCRIPTION
Refactors image swiper to make it a bit less complex:
 - Make sizes mandatory. No default to `image.sizes`. Never is the case rn.
 - Change input from custom swiper options to slides per view. It's the only thing provided rn. Make it mandatory so that no need to take into account when not provided.
 - Remove loop / rewind autofix. Not looping either rewinding right now.
