### PR TITLE
perf: add virtual slides to reduce network load

### DIFF
--- a/lighthouserc.cjs
+++ b/lighthouserc.cjs
@@ -19,8 +19,7 @@ module.exports = {
           matchingUrlPattern: '.*',
           preset: 'lighthouse:no-pwa',
           assertions: {
-            'uses-responsive-images': ['error', { maxLength: 16 }],
-            'total-byte-weight': 'warn',
+            'uses-responsive-images': ['error', { maxLength: 2 }],
           },
         },
         // Non-project detail

--- a/src/app/projects/images-swiper/images-swiper.component.ts
+++ b/src/app/projects/images-swiper/images-swiper.component.ts
@@ -12,6 +12,7 @@ import {
   Keyboard,
   Navigation,
   Pagination,
+  Virtual,
 } from 'swiper/modules'
 import { ResponsiveImage } from '../../common/images/image'
 import { SwiperDirective } from './swiper.directive'
@@ -46,7 +47,7 @@ export class ImagesSwiperComponent {
 }
 
 const DEFAULT_SWIPER_OPTIONS = {
-  modules: [A11y, Autoplay, Keyboard, Navigation, Pagination],
+  modules: [A11y, Autoplay, Keyboard, Navigation, Pagination, Virtual],
   injectStylesUrls: ['/swiper.css'],
   a11y: {
     enabled: false,
@@ -65,5 +66,8 @@ const DEFAULT_SWIPER_OPTIONS = {
     enabled: true,
     clickable: true,
     dynamicBullets: true,
+  },
+  virtual: {
+    enabled: true,
   },
 } satisfies SwiperOptions

--- a/src/app/projects/project-detail-page/project-detail-page.component.ts
+++ b/src/app/projects/project-detail-page/project-detail-page.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, effect } from '@angular/core'
+import { Component, computed, effect, Inject, PLATFORM_ID } from '@angular/core'
 import { map } from 'rxjs'
 import { ActivatedRoute } from '@angular/router'
 import { ProjectDetailRouteData } from './projects-routes-data'
@@ -12,6 +12,7 @@ import {
   PROJECT_DETAIL_PAGE_SWIPER_BY_SIZE,
   ProjectDetailPageSwiper,
 } from '@/app/projects/project-detail-page/project-detail-page-swipers'
+import { isPlatformBrowser } from '@angular/common'
 
 @Component({
   templateUrl: './project-detail-page.component.html',
@@ -44,8 +45,13 @@ export class ProjectDetailPageComponent {
       return []
     }
     return albums.map((album) => {
+      const swiper = PROJECT_DETAIL_PAGE_SWIPER_BY_SIZE[album.size]
+      const imagesLimit = isPlatformBrowser(this._platformObject)
+        ? Infinity
+        : swiper.slidesPerView
       return {
         ...album,
+        images: album.images.slice(0, imagesLimit),
         ...PROJECT_DETAIL_PAGE_SWIPER_BY_SIZE[album.size],
       }
     })
@@ -54,6 +60,7 @@ export class ProjectDetailPageComponent {
 
   constructor(
     private readonly _activatedRoute: ActivatedRoute,
+    @Inject(PLATFORM_ID) private readonly _platformObject: object,
     ngxMetaService: NgxMetaService,
   ) {
     effect(() => {

--- a/src/app/projects/projects-list-page/project-list-item/project-list-item.component.html
+++ b/src/app/projects/projects-list-page/project-list-item/project-list-item.component.html
@@ -1,30 +1,31 @@
+@let item = _item();
 <div class="text-and-images">
   <div class="texts">
     <span class="title">
-      @if (item().hasDetails) {
-        <a [routerLink]="[_PROJECTS_PATH, item().slug]"
+      @if (item.hasDetails) {
+        <a [routerLink]="[_PROJECTS_PATH, item.slug]"
           ><ng-container [ngTemplateOutlet]="title"></ng-container
         ></a>
       } @else {
-        {{ item().title }}
+        {{ item.title }}
       }
       <ng-template #title>
-        {{ item().title }}
+        {{ item.title }}
       </ng-template>
     </span>
     <span class="subtitle">
-      {{ item().subtitle }}
+      {{ item.subtitle }}
     </span>
-    @if (item().quote) {
-      <span class="quote"> "{{ item().quote }}" </span>
+    @if (item.quote) {
+      <span class="quote"> "{{ item.quote }}" </span>
     }
-    <div class="description" [innerHtml]="item().description"></div>
+    <div class="description" [innerHtml]="item.description"></div>
   </div>
-  @let previewImages = item().previewImages;
+  @let previewImages = item.previewImages;
   @if (previewImages && previewImages.length) {
     <app-images-swiper
       [images]="previewImages"
-      [sizes]="item().previewImageSizes"
+      [sizes]="item.previewImageSizes"
       [priority]="priority()"
       [slidesPerView]="_SLIDES_PER_VIEW"
     ></app-images-swiper>

--- a/src/app/projects/projects-list-page/project-list-item/project-list-item.component.ts
+++ b/src/app/projects/projects-list-page/project-list-item/project-list-item.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, input } from '@angular/core'
+import { Component, computed, inject, input, PLATFORM_ID } from '@angular/core'
 import {
   mapSocialRefToSocialViewModel,
   SocialRefViewModel,
@@ -6,12 +6,13 @@ import {
 import { PROJECTS_PATH } from '@/app/common/routing/paths'
 import { ImagesSwiperComponent } from '../../images-swiper/images-swiper.component'
 import { RouterLink } from '@angular/router'
-import { NgTemplateOutlet } from '@angular/common'
+import { isPlatformBrowser, NgTemplateOutlet } from '@angular/common'
 import {
   PROJECT_LIST_ITEM_SLIDES_PER_VIEW,
   ProjectListItem,
   ProjectListItemCredit,
 } from '../../project'
+import { PROJECT_DETAIL_PAGE_SWIPER_BY_SIZE } from '@/app/projects/project-detail-page/project-detail-page-swipers'
 
 @Component({
   selector: 'app-project-list-item',
@@ -23,6 +24,10 @@ import {
 export class ProjectListItemComponent {
   readonly priority = input(false)
   readonly item = input.required<ProjectListItem>()
+  protected readonly _item = computed<ProjectListItem>(() => ({
+    ...this.item(),
+    previewImages: this.item().previewImages.slice(0, this._imagesLimit),
+  }))
   readonly credits = computed<readonly CreditViewModel[]>(
     () =>
       this.item().credits?.map((projectListItemCredit) => ({
@@ -35,6 +40,13 @@ export class ProjectListItemComponent {
 
   protected readonly _PROJECTS_PATH = PROJECTS_PATH
   protected readonly _SLIDES_PER_VIEW = PROJECT_LIST_ITEM_SLIDES_PER_VIEW
+  private readonly _imagesLimit = isPlatformBrowser(inject(PLATFORM_ID))
+    ? Infinity
+    : Math.max(
+        ...Object.values(PROJECT_DETAIL_PAGE_SWIPER_BY_SIZE).map(
+          (swiper) => swiper.slidesPerView,
+        ),
+      )
 }
 
 type CreditViewModel = Omit<ProjectListItemCredit, 'social'> & {


### PR DESCRIPTION
In #632 , found one main issue regarding performance is loading way too many images. Here, virtual slides from Swiper.js are leveraged so that just few images end up in the DOM. 

This is done by limiting the images that end up in the HTML markup when doing SSR/SSG. But providing them all in the browser. This way, browser won't load all images when loading the page initially, as they aren't in the markup. When hydrated, they will be, but just for a moment and then Swiper.js will remove them. So good enough, cause browser won't download them. Same will happen when switching from page to page. Swiper.js will take care of just maintaining few of them in the DOM.

This allows to pass the `total-byte-weight` Lighthouse audit assertion. So removing the exception for it. Reducing also the `uses-responsive-images`. Given that now there are less in the markup, less are detected. So can reduce the limit.