### PR TITLE
perf: reduce layout shift in project detail

### DIFF
--- a/src/app/projects/images-swiper/images-swiper.component.html
+++ b/src/app/projects/images-swiper/images-swiper.component.html
@@ -1,5 +1,12 @@
 @if (images().length) {
-  <swiper-container [appSwiper]="_swiperOptions()" init="false">
+  @let firstImage = images()[0];
+  <swiper-container
+    [appSwiper]="_swiperOptions()"
+    init="false"
+    [style.aspect-ratio]="
+      (firstImage.width * slidesPerView()) / firstImage.height
+    "
+  >
     @for (image of images(); track image; let i = $index) {
       <swiper-slide>
         <img


### PR DESCRIPTION
By ensuring swiper slides take the proper space before image is loaded.

Tried applying to `swiper-slide`. ~However, Swiper.js also sets the inline `width` property. Hence when loading Swiper.js a layout shift happens due to this `width` being reset.~ Seems it's because another reason. See #643 

Setting it to `swiper-container` instead then
