### PR TITLE
perf: ensure auto size doesn't come with perf issues

### DIFF
--- a/src/app/projects/images-swiper/images-swiper.component.html
+++ b/src/app/projects/images-swiper/images-swiper.component.html
@@ -15,14 +15,15 @@
         [style.width.%]="100 / slidesPerView()"
         [style.aspect-ratio]="image.width / image.height"
       >
+        @let isPriority = priority() && i < slidesPerView();
         <img
           [ngSrc]="image.src"
           [width]="image.width"
           [height]="image.height"
           [alt]="image.alt || 'Image'"
           [ngSrcset]="image.breakpoints | toNgSrcSet"
-          [sizes]="sizes()"
-          [priority]="priority() && i < slidesPerView()"
+          [sizes]="isPriority ? sizes() : 'auto,' + sizes()"
+          [priority]="isPriority"
           [loaderParams]="image | toLoaderParams"
         />
       </swiper-slide>


### PR DESCRIPTION
After last improvements to image swiper, seems was ready to update to Angular v19 with the new auto `auto` 🥁 in responsive images `sizes`. However seems not, as tests fail again. After inspecting, seems that 818w breakpoints are being loaded when Moto G device is used in Lighthouse to view the page. This is quite weird. However, finally was able to reproduce the behavior by removing the `swiper-slide` 's  `width` set by Swiper.js. In this case, the intrinsic size of 350x150 was entering the scene. 

Which meant taking the 409w breakpoint. Multiplied by 1.8 -> 736w adjusted for density. The next one bigger to that is the 818w one.

Solution is to apply a width to the slide whilst swiper loads. This way we ensure the proper intrinsic size is given even before Swiper.js has loaded. Can't apply `width` cause Swiper.js will set it and can mess up things. Hence using `max-width`.

Finally, `width: auto` is replaced by `object-fit: contain`. Otherwise, tech material and concept images aspect ratio was invalid due to using the intrinsic size. Lighthouse properly detected this in their tests. `object-fit: contain` is needed for `max-height` clause. In that scenario we want the images to fit the screen. Not to hide some of the laterals. No need then for `text-align: center` on slide then.

Investigating a bit more, found out that `autoplay` changes things around :/ For instance the first image of `Look 5 "Diffusion"` has intrinsic size of 409px width if autoplay is disabled. But turns into 718 or 818w if autoplay is enabled. Not sure why :( After playing manually, seems that when the image is out of the viewport, `auto` in `sizes` can't calculate the size of the image. Hence defaults to `100vw`. Hence taking the 818w breakpoint. Seems that just autoplaying visible ones will be needed. Otherwise this keeps messing with the audit. Done in #650. However, still something is off. Sizes `auto` shouldn't be there because when they're not in the viewport because it will be the next slide, sizes `auto` triggers loading the wrong resource due to the `100vw` default.

PD: Something weird happened: Lighthouse tests passed, despite 8 images appearing as unsized in the report. Quite weird. The CI run didn't report any unsized elements. However, they appear in the report. Both in the CI run report URL and in the check one (it's the same one indeed). 