### PR TITLE
fix: blue box below swiper slides

### DIFF
--- a/src/app/projects/images-swiper/images-swiper.component.html
+++ b/src/app/projects/images-swiper/images-swiper.component.html
@@ -1,14 +1,10 @@
 @if (images().length) {
-  @let firstImage = images()[0];
-  <swiper-container
-    [appSwiper]="_swiperOptions()"
-    init="false"
-    [style.aspect-ratio]="
-      (firstImage.width * slidesPerView()) / firstImage.height
-    "
-  >
+  <swiper-container [appSwiper]="_swiperOptions()" init="false">
     @for (image of images(); track image; let i = $index) {
-      <swiper-slide>
+      <swiper-slide
+        [style.width.%]="100 / slidesPerView()"
+        [style.aspect-ratio]="image.width / image.height"
+      >
         <img
           [ngSrc]="image.src"
           [width]="image.width"

--- a/src/app/projects/images-swiper/images-swiper.component.scss
+++ b/src/app/projects/images-swiper/images-swiper.component.scss
@@ -3,17 +3,21 @@
 
 swiper-container {
   display: block;
+  // 👇 If Swiper.js isn't there it'd display as an horizontal list of slides
   white-space: nowrap;
-  overflow-x: scroll;
+  // 👇 If scroll, weird blue box appears even after Swiper.js inits
+  overflow: hidden;
 }
 
 swiper-slide {
-  text-align: center;
+  display: inline-block;
+  // 👇 So layout applies if no images in there
+  max-height: content.$available-height;
 }
 
 img {
-  max-height: content.$available-height;
-  width: auto;
+  object-fit: contain;
+  max-height: 100%;
 }
 
 $balanced-luminance-color: theme.$accent;


### PR DESCRIPTION
A blue box has started appearing below swiper slides. Seems it's due to `scroll` overflow style. Removing it then and hiding it instead.

![image](https://github.com/user-attachments/assets/49a3d285-8c30-42db-a935-199687f9c8a6)
![image](https://github.com/user-attachments/assets/0f02f094-92a9-4651-8562-7296191f430f)


Reason of `white-space: nowrap` and `overflow` was to perform the same layout that Swiper.js will set with JS when initialized. So no layout shifts happen. `scroll` was the most similar and could allow users without JS to see all content. But seems that it's at the expense of this annoying blue bar/box. Removing it then. Not a usual scenario anyway.

Also moves the `max-height` constraints from `img` to the slide. This way the base layout can be tested without the use of images. To simulate what's being laid out when no images have been loaded yet. Which is also useful to avoid layout shifts.

Finally the aspect ratio constraint is also moved from the swiper container to the slide. This way, all the layout is based on the slide, which is actually closer to the reality needs. This helps when needing to perform layout tests on the main project list screen. Where the width + aspect ratio doesn't determine height. As the `max-height` constraint applies. And given that one is in the slide, and not in the container, it doesn't take effect and therefore overflows.