### PR TITLE
perf: reduce layout shift in project detail (again!)

### DIFF
--- a/src/app/projects/images-swiper/images-swiper.component.html
+++ b/src/app/projects/images-swiper/images-swiper.component.html
@@ -1,5 +1,12 @@
 @if (images().length) {
-  <swiper-container [appSwiper]="_swiperOptions()" init="false">
+  @let firstImage = images()[0];
+  <swiper-container
+    [appSwiper]="_swiperOptions()"
+    init="false"
+    [style.aspect-ratio]="
+      (firstImage.width * slidesPerView()) / firstImage.height
+    "
+  >
     @for (image of images(); track image; let i = $index) {
       <swiper-slide
         [style.width.%]="100 / slidesPerView()"

--- a/src/app/projects/images-swiper/images-swiper.component.scss
+++ b/src/app/projects/images-swiper/images-swiper.component.scss
@@ -9,10 +9,14 @@ swiper-container {
   overflow: hidden;
 }
 
+swiper-container,
 swiper-slide {
-  display: inline-block;
   // 👇 So layout applies if no images in there
   max-height: content.$available-height;
+}
+
+swiper-slide {
+  display: inline-block;
 }
 
 img {


### PR DESCRIPTION
In #642 thought that `swiper-container` aspect ratio was no longer needed in order to apply base layout in project detail. But it is actually needed to avoid layout shifts in mobile screens. Despite without this change the base layout is correct due to the slides layout, seems there's an instant where it's not and this fixes it.

After some investigation, seems that instant is when Swiper.js Element rewrites the HTML to insert its shadow DOM things:
https://github.com/nolimits4web/swiper/blob/v11.2.6/src/swiper-element.mjs#L123
