### PR TITLE
refactor: move swiper element init to directive

### DIFF
--- a/src/app/projects/images-swiper/images-swiper.component.ts
+++ b/src/app/projects/images-swiper/images-swiper.component.ts
@@ -4,7 +4,6 @@ import {
   CUSTOM_ELEMENTS_SCHEMA,
   input,
 } from '@angular/core'
-import { register as registerSwiper } from 'swiper/element'
 import { SwiperOptions } from 'swiper/types'
 import {
   A11y,
@@ -19,10 +18,6 @@ import { SwiperDirective } from './swiper.directive'
 import { NgOptimizedImage } from '@angular/common'
 import { ToNgSrcSet } from '@/app/common/images/to-ng-src-set'
 import { ToLoaderParams } from '@/app/common/images/loader-params'
-
-// There's no fancier way to install Web Components in Angular :P
-// https://stackoverflow.com/a/75353889/3263250
-registerSwiper()
 
 @Component({
   selector: 'app-images-swiper',

--- a/src/app/projects/images-swiper/swiper.directive.ts
+++ b/src/app/projects/images-swiper/swiper.directive.ts
@@ -1,6 +1,13 @@
+import {
+  register as registerSwiper,
+  type SwiperContainer,
+} from 'swiper/element'
 import { Directive, effect, ElementRef, input, NgZone } from '@angular/core'
 import { SwiperOptions } from 'swiper/types'
-import { type SwiperContainer } from 'swiper/swiper-element'
+
+// There's no fancier way to install Web Components in Angular :P
+// https://stackoverflow.com/a/75353889/3263250
+registerSwiper()
 
 @Directive({
   selector: '[appSwiper]',


### PR DESCRIPTION
Feels more appropriate. As there could be multiple components using Swiper.js. Right now it's only the images one.
