### PR TITLE
refactor: use max-height instead of awkward fix

### DIFF
--- a/src/app/projects/images-swiper/images-swiper.component.html
+++ b/src/app/projects/images-swiper/images-swiper.component.html
@@ -6,7 +6,7 @@
   <swiper-container
     [appSwiper]="_swiperOptions()"
     init="false"
-    [style.aspect-ratio]="fixContainerAspectRatio() ? aspectRatio : undefined"
+    [style.aspect-ratio]="aspectRatio"
   >
     @for (image of images(); track image; let i = $index) {
       <!-- 👇 Base layout until Swiper.js initializes -->

--- a/src/app/projects/images-swiper/images-swiper.component.scss
+++ b/src/app/projects/images-swiper/images-swiper.component.scss
@@ -9,15 +9,11 @@ swiper-container {
   overflow: hidden;
 }
 
-swiper-container,
-swiper-slide {
-  // 👇 So layout applies if no images in there
-  max-height: content.$available-height;
-}
-
 swiper-slide {
   // 👇 To size a slide. See HTML to see why needs to be sized.
   display: inline-block;
+  // 👇 So layout applies if no images in there
+  max-height: content.$available-height;
 }
 
 img {

--- a/src/app/projects/images-swiper/images-swiper.component.ts
+++ b/src/app/projects/images-swiper/images-swiper.component.ts
@@ -35,7 +35,6 @@ export class ImagesSwiperComponent {
   readonly sizes = input.required<string>()
   readonly slidesPerView = input.required<number>()
   readonly priority = input(false)
-  readonly fixContainerAspectRatio = input(false)
   protected readonly _swiperOptions = computed<SwiperOptions>(() => ({
     ...DEFAULT_SWIPER_OPTIONS,
     slidesPerView: this.slidesPerView(),

--- a/src/app/projects/project-detail-page/project-detail-page.component.html
+++ b/src/app/projects/project-detail-page/project-detail-page.component.html
@@ -22,7 +22,6 @@
       [slidesPerView]="album.slidesPerView"
       [style.max-width.px]="album.maxWidthPx"
       [priority]="index < _maxSwipersPerViewport"
-      [fixContainerAspectRatio]="true"
     ></app-images-swiper>
   </div>
 }


### PR DESCRIPTION
To fix the #647 issue. Same effect. With a less awkward / polluting API. The PR got merged before was ready.
