### PR TITLE
fix: only add swiper container aspect ratio to project detail

### DIFF
--- a/src/app/projects/images-swiper/images-swiper.component.html
+++ b/src/app/projects/images-swiper/images-swiper.component.html
@@ -6,7 +6,7 @@
   <swiper-container
     [appSwiper]="_swiperOptions()"
     init="false"
-    [style.aspect-ratio]="aspectRatio"
+    [style.aspect-ratio]="fixContainerAspectRatio() ? aspectRatio : undefined"
   >
     @for (image of images(); track image; let i = $index) {
       <!-- 👇 Base layout until Swiper.js initializes -->

--- a/src/app/projects/images-swiper/images-swiper.component.ts
+++ b/src/app/projects/images-swiper/images-swiper.component.ts
@@ -35,6 +35,7 @@ export class ImagesSwiperComponent {
   readonly sizes = input.required<string>()
   readonly slidesPerView = input.required<number>()
   readonly priority = input(false)
+  readonly fixContainerAspectRatio = input(false)
   protected readonly _swiperOptions = computed<SwiperOptions>(() => ({
     ...DEFAULT_SWIPER_OPTIONS,
     slidesPerView: this.slidesPerView(),

--- a/src/app/projects/project-detail-page/project-detail-page.component.html
+++ b/src/app/projects/project-detail-page/project-detail-page.component.html
@@ -22,6 +22,7 @@
       [slidesPerView]="album.slidesPerView"
       [style.max-width.px]="album.maxWidthPx"
       [priority]="index < _maxSwipersPerViewport"
+      [fixContainerAspectRatio]="true"
     ></app-images-swiper>
   </div>
 }


### PR DESCRIPTION
Otherwise in project list, this makes that the last item has extra white space at the end because of that. Not sure why just last one tbh.
