### PR TITLE
feat: only autoplay viewable swipers

### DIFF
--- a/src/app/logo/logo.ts
+++ b/src/app/logo/logo.ts
@@ -2,6 +2,8 @@
 import { ImageDimensions } from '@/app/common/images/image'
 
 export const LOGO_MAX_HEIGHT_PX = 55
+const VERTICAL_PADDING_PX = 32
+export const LOGO_HEIGHT_PX = LOGO_MAX_HEIGHT_PX + VERTICAL_PADDING_PX
 export const getLogoMaxWidthFromDimensions = ({
   width,
   height,

--- a/src/app/projects/images-swiper/images-swiper.component.html
+++ b/src/app/projects/images-swiper/images-swiper.component.html
@@ -5,6 +5,7 @@
   @let aspectRatio = (firstImage.width * slidesPerView()) / firstImage.height;
   <swiper-container
     [appSwiper]="_swiperOptions()"
+    appSwiperAutoplayScroll
     init="false"
     [style.aspect-ratio]="fixContainerAspectRatio() ? aspectRatio : undefined"
   >

--- a/src/app/projects/images-swiper/images-swiper.component.ts
+++ b/src/app/projects/images-swiper/images-swiper.component.ts
@@ -18,13 +18,20 @@ import { SwiperDirective } from './swiper.directive'
 import { NgOptimizedImage } from '@angular/common'
 import { ToNgSrcSet } from '@/app/common/images/to-ng-src-set'
 import { ToLoaderParams } from '@/app/common/images/loader-params'
+import { SwiperAutoplayScrollDirective } from '@/app/projects/images-swiper/swiper-autoplay-scroll.directive'
 
 @Component({
   selector: 'app-images-swiper',
   templateUrl: './images-swiper.component.html',
   styleUrls: ['./images-swiper.component.scss'],
   standalone: true,
-  imports: [SwiperDirective, NgOptimizedImage, ToNgSrcSet, ToLoaderParams],
+  imports: [
+    SwiperDirective,
+    NgOptimizedImage,
+    ToNgSrcSet,
+    ToLoaderParams,
+    SwiperAutoplayScrollDirective,
+  ],
   // Use swiper web components
   // A better approach would be to declare those but there's no easy way
   // https://stackoverflow.com/a/43012920/3263250

--- a/src/app/projects/images-swiper/swiper-autoplay-scroll.directive.spec.ts
+++ b/src/app/projects/images-swiper/swiper-autoplay-scroll.directive.spec.ts
@@ -1,8 +1,65 @@
-import { SwiperAutoplayScrollDirective } from './swiper-autoplay-scroll.directive'
+import {
+  SWIPER_AUTOPLAY_INTERSECTION_OBSERVER,
+  SwiperAutoplayScrollDirective,
+} from './swiper-autoplay-scroll.directive'
+import { Component } from '@angular/core'
+import { TestBed } from '@angular/core/testing'
+import { testbedSetup } from '../../../test/testbed-setup'
 
 describe('SwiperAutoplayScrollDirective', () => {
   it('should create an instance', () => {
-    const directive = new SwiperAutoplayScrollDirective()
+    const fixture = setupHostComponent()
+    const directive = fixture.componentRef.injector.get(
+      SwiperAutoplayScrollDirective,
+    )
     expect(directive).toBeTruthy()
   })
+
+  it('should observe on init', () => {
+    const intersectionObserver = makeIntersectionObserverSpy()
+    const fixture = setupHostComponent({ intersectionObserver })
+    fixture.detectChanges()
+
+    expect(intersectionObserver.observe).toHaveBeenCalledOnceWith(
+      fixture.debugElement.nativeElement,
+    )
+  })
+
+  it('should unobserve on destroy', () => {
+    const intersectionObserver = makeIntersectionObserverSpy()
+    const fixture = setupHostComponent({ intersectionObserver })
+
+    fixture.destroy()
+
+    expect(intersectionObserver.unobserve).toHaveBeenCalledOnceWith(
+      fixture.debugElement.nativeElement,
+    )
+  })
 })
+
+const setupHostComponent = (
+  opts: { intersectionObserver?: IntersectionObserver } = {},
+) => {
+  testbedSetup({
+    providers: [
+      opts.intersectionObserver
+        ? {
+            provide: SWIPER_AUTOPLAY_INTERSECTION_OBSERVER,
+            useValue: opts.intersectionObserver,
+          }
+        : [],
+    ],
+  })
+
+  @Component({
+    template: ``,
+    hostDirectives: [SwiperAutoplayScrollDirective],
+    standalone: true,
+  })
+  class HostComponent {}
+
+  return TestBed.createComponent(HostComponent)
+}
+
+const makeIntersectionObserverSpy = () =>
+  jasmine.createSpyObj<IntersectionObserver>('io', ['observe', 'unobserve'])

--- a/src/app/projects/images-swiper/swiper-autoplay-scroll.directive.spec.ts
+++ b/src/app/projects/images-swiper/swiper-autoplay-scroll.directive.spec.ts
@@ -1,0 +1,8 @@
+import { SwiperAutoplayScrollDirective } from './swiper-autoplay-scroll.directive'
+
+describe('SwiperAutoplayScrollDirective', () => {
+  it('should create an instance', () => {
+    const directive = new SwiperAutoplayScrollDirective()
+    expect(directive).toBeTruthy()
+  })
+})

--- a/src/app/projects/images-swiper/swiper-autoplay-scroll.directive.ts
+++ b/src/app/projects/images-swiper/swiper-autoplay-scroll.directive.ts
@@ -1,10 +1,10 @@
 import {
   Directive,
-  effect,
   ElementRef,
   inject,
   InjectionToken,
   OnDestroy,
+  OnInit,
   PLATFORM_ID,
 } from '@angular/core'
 import { SwiperContainer } from 'swiper/swiper-element'
@@ -15,13 +15,12 @@ import { isPlatformBrowser } from '@angular/common'
   selector: '[appSwiperAutoplayScroll]',
   standalone: true,
 })
-export class SwiperAutoplayScrollDirective implements OnDestroy {
+export class SwiperAutoplayScrollDirective implements OnInit, OnDestroy {
   private readonly _observer = inject(SWIPER_AUTOPLAY_INTERSECTION_OBSERVER)
+  private readonly _elRef = inject(ElementRef)
 
-  constructor(private readonly _elRef: ElementRef<HTMLElement>) {
-    effect(() => {
-      this._observer?.observe(this._elRef.nativeElement)
-    })
+  ngOnInit() {
+    this._observer?.observe(this._elRef.nativeElement)
   }
 
   ngOnDestroy() {
@@ -29,7 +28,7 @@ export class SwiperAutoplayScrollDirective implements OnDestroy {
   }
 }
 
-const SWIPER_AUTOPLAY_INTERSECTION_OBSERVER =
+export const SWIPER_AUTOPLAY_INTERSECTION_OBSERVER =
   new InjectionToken<IntersectionObserver | null>('', {
     factory: () =>
       isPlatformBrowser(inject(PLATFORM_ID))

--- a/src/app/projects/images-swiper/swiper-autoplay-scroll.directive.ts
+++ b/src/app/projects/images-swiper/swiper-autoplay-scroll.directive.ts
@@ -1,0 +1,57 @@
+import {
+  Directive,
+  effect,
+  ElementRef,
+  inject,
+  InjectionToken,
+  OnDestroy,
+  PLATFORM_ID,
+} from '@angular/core'
+import { SwiperContainer } from 'swiper/swiper-element'
+import { LOGO_HEIGHT_PX } from '@/app/logo/logo'
+import { isPlatformBrowser } from '@angular/common'
+
+@Directive({
+  selector: '[appSwiperAutoplayScroll]',
+  standalone: true,
+})
+export class SwiperAutoplayScrollDirective implements OnDestroy {
+  private readonly _observer = inject(SWIPER_AUTOPLAY_INTERSECTION_OBSERVER)
+
+  constructor(private readonly _elRef: ElementRef<HTMLElement>) {
+    effect(() => {
+      this._observer?.observe(this._elRef.nativeElement)
+    })
+  }
+
+  ngOnDestroy() {
+    this._observer?.unobserve(this._elRef.nativeElement)
+  }
+}
+
+const SWIPER_AUTOPLAY_INTERSECTION_OBSERVER =
+  new InjectionToken<IntersectionObserver | null>('', {
+    factory: () =>
+      isPlatformBrowser(inject(PLATFORM_ID))
+        ? createIntersectionObserver()
+        : null,
+  })
+
+const createIntersectionObserver = () =>
+  new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        const { isIntersecting, target } = entry
+        const swiperInstance = (target as Partial<SwiperContainer>).swiper
+        if (!swiperInstance) {
+          return
+        }
+        if (!isIntersecting) {
+          swiperInstance.autoplay.stop()
+          return
+        }
+        swiperInstance.autoplay.start()
+      })
+    },
+    { rootMargin: `${-LOGO_HEIGHT_PX}px 0px 0px 0px`, threshold: 0.5 },
+  )

--- a/src/app/projects/images-swiper/swiper.directive.ts
+++ b/src/app/projects/images-swiper/swiper.directive.ts
@@ -16,7 +16,7 @@ registerSwiper()
 export class SwiperDirective {
   readonly options = input.required<SwiperOptions>({ alias: 'appSwiper' })
 
-  constructor(elRef: ElementRef<Element & SwiperContainer>) {
+  constructor(readonly elRef: ElementRef<Element & Partial<SwiperContainer>>) {
     effect(() => {
       const element = elRef.nativeElement
       const initializer = element.initialize

--- a/src/app/projects/images-swiper/swiper.directive.ts
+++ b/src/app/projects/images-swiper/swiper.directive.ts
@@ -16,7 +16,7 @@ registerSwiper()
 export class SwiperDirective {
   readonly options = input.required<SwiperOptions>({ alias: 'appSwiper' })
 
-  constructor(readonly elRef: ElementRef<Element & Partial<SwiperContainer>>) {
+  constructor(elRef: ElementRef<Element & Partial<SwiperContainer>>) {
     effect(() => {
       const element = elRef.nativeElement
       const initializer = element.initialize

--- a/src/sass/_logo.scss
+++ b/src/sass/_logo.scss
@@ -1,6 +1,6 @@
 @use 'paddings';
 
-$padding-vertical: paddings.$m;
 // Keep in sync with component for responsive sizing!
+$padding-vertical: paddings.$m;
 $height-image: 55px;
 $height: calc($height-image + $padding-vertical * 2);


### PR DESCRIPTION
By using `IntersectionObserver`. This will help #641. See there why this is needed. TL;DR: so that `auto` in `sizes` isn't invalid due to being out of the viewport. Plus less images will be downloaded.
