### PR TITLE
refactor: implement own optimized image to avoid auto sizes

### DIFF
--- a/src/app/common/images/loader-params.ts
+++ b/src/app/common/images/loader-params.ts
@@ -4,11 +4,12 @@ import { areBreakpointsUnsigned, LoaderParams, ResponsiveImage } from './image'
 @Pipe({ name: 'toLoaderParams', standalone: true, pure: true })
 export class ToLoaderParams implements PipeTransform {
   transform(image: ResponsiveImage): LoaderParams {
-    const { breakpoints } = image
-    return {
-      signaturesByBreakpoint: areBreakpointsUnsigned(breakpoints)
-        ? undefined
-        : breakpoints,
-    }
+    return toLoaderParams(image)
   }
 }
+
+export const toLoaderParams = ({ breakpoints }: ResponsiveImage) => ({
+  signaturesByBreakpoint: areBreakpointsUnsigned(breakpoints)
+    ? undefined
+    : breakpoints,
+})

--- a/src/app/common/images/loader-params.ts
+++ b/src/app/common/images/loader-params.ts
@@ -1,11 +1,9 @@
 import { Pipe, PipeTransform } from '@angular/core'
-import { areBreakpointsUnsigned, LoaderParams, ResponsiveImage } from './image'
+import { areBreakpointsUnsigned, ResponsiveImage } from './image'
 
 @Pipe({ name: 'toLoaderParams', standalone: true, pure: true })
 export class ToLoaderParams implements PipeTransform {
-  transform(image: ResponsiveImage): LoaderParams {
-    return toLoaderParams(image)
-  }
+  transform = toLoaderParams
 }
 
 export const toLoaderParams = ({ breakpoints }: ResponsiveImage) => ({

--- a/src/app/common/images/to-ng-src-set.ts
+++ b/src/app/common/images/to-ng-src-set.ts
@@ -8,11 +8,15 @@ import {
 @Pipe({ name: 'toNgSrcSet', standalone: true, pure: true })
 export class ToNgSrcSet implements PipeTransform {
   transform(breakpoints: ResponsiveImageBreakpoints): string {
-    const unsignedBreakpoints = areBreakpointsUnsigned(breakpoints)
-      ? breakpoints
-      : Object.keys(breakpoints)
-          .filter((breakpoint) => breakpoint !== ORIGINAL_SRC_BREAKPOINT)
-          .map((breakpoint) => parseInt(breakpoint))
-    return unsignedBreakpoints.map((breakpoint) => `${breakpoint}w`).join(', ')
+    return unsignedBreakpoints(breakpoints)
+      .map((breakpoint) => `${breakpoint}w`)
+      .join(', ')
   }
 }
+
+export const unsignedBreakpoints = (breakpoints: ResponsiveImageBreakpoints) =>
+  areBreakpointsUnsigned(breakpoints)
+    ? breakpoints
+    : Object.keys(breakpoints)
+        .filter((breakpoint) => breakpoint !== ORIGINAL_SRC_BREAKPOINT)
+        .map((breakpoint) => parseInt(breakpoint))

--- a/src/app/projects/images-swiper/images-swiper.component.html
+++ b/src/app/projects/images-swiper/images-swiper.component.html
@@ -9,21 +9,22 @@
     init="false"
     [style.aspect-ratio]="fixContainerAspectRatio() ? aspectRatio : undefined"
   >
-    @for (image of images(); track image; let i = $index) {
+    @for (image of _imageViewModels(); track image) {
       <!-- 👇 Base layout until Swiper.js initializes -->
       <swiper-slide
         [style.width.%]="100 / slidesPerView()"
         [style.aspect-ratio]="image.width / image.height"
       >
+        <!--suppress AngularNgOptimizedImage - Can't use due to auto `auto` sizes -->
         <img
-          [ngSrc]="image.src"
+          [src]="image.src"
           [width]="image.width"
           [height]="image.height"
-          [alt]="image.alt || 'Image'"
-          [ngSrcset]="image.breakpoints | toNgSrcSet"
-          [sizes]="sizes()"
-          [priority]="priority() && i < slidesPerView()"
-          [loaderParams]="image | toLoaderParams"
+          [alt]="image.alt"
+          [srcset]="image.srcset"
+          [sizes]="image.sizes"
+          [attr.loading]="image.loading"
+          [attr.fetchpriority]="image.fetchPriority"
         />
       </swiper-slide>
     }


### PR DESCRIPTION
In Angular v19, `NgOptimizedImage` prepends `auto` to `sizes` if some are specified. However, this is not good in our scenario. Because when an image is not yet in the viewport, seems that the default size for `auto` in `sizes` is `100vw`. Which is incorrect. Therefore the wrong image from `srcset` is loaded. See more in #641.

Eventually seems the only option is to actually code the `img` with its `srcset` & `sizes` ourselves. Until in Angular we can somehow disable this behavior. Or not update to Angular v19. But don't want to miss last updates. That'd be a mantainability issue. This is also kind of one. But not so big in comparison. HTML spec will rarely change.
