### PR TITLE
refactor: use observables for services

### DIFF
--- a/src/app/common/json/fetcher/http-json-fetcher.ts
+++ b/src/app/common/json/fetcher/http-json-fetcher.ts
@@ -1,6 +1,5 @@
 import { JSON_FILES_DIR, JsonFetcher } from './json-fetcher'
 import { HttpClient } from '@angular/common/http'
-import { firstValueFrom } from 'rxjs'
 import { inject, InjectionToken } from '@angular/core'
 import { APP_BASE_HREF } from '@angular/common'
 import { appendJsonExtensionIfNeeded } from '@/app/common/json/json-extension-utils'
@@ -12,13 +11,11 @@ export const HTTP_JSON_FETCHER = new InjectionToken<JsonFetcher>(
       const httpClient = inject(HttpClient)
       const baseHref = inject(APP_BASE_HREF)
       return <T extends object>(...pathSegments: readonly string[]) =>
-        firstValueFrom(
-          httpClient.get<T>(
-            appendJsonExtensionIfNeeded(
-              [baseHref, JSON_FILES_DIR, ...pathSegments]
-                .join('/')
-                .replace(/^\//, ''),
-            ),
+        httpClient.get<T>(
+          appendJsonExtensionIfNeeded(
+            [baseHref, JSON_FILES_DIR, ...pathSegments]
+              .join('/')
+              .replace(/^\//, ''),
           ),
         )
     },

--- a/src/app/common/json/fetcher/json-fetcher.ts
+++ b/src/app/common/json/fetcher/json-fetcher.ts
@@ -1,10 +1,11 @@
 import { InjectionToken, Provider } from '@angular/core'
 import { CONTENTS_DIR } from '../../directories'
+import { Observable } from 'rxjs'
 
 export const JSON_FETCHER = new InjectionToken<JsonFetcher>('JSON fetcher')
 export type JsonFetcher = <T extends object>(
   ...pathSegments: string[]
-) => Promise<T>
+) => Observable<T>
 export const provideJsonFetcher = (
   jsonFetcherToken: InjectionToken<JsonFetcher>,
 ): Provider => ({

--- a/src/app/common/json/fetcher/local-json-fetcher.ts
+++ b/src/app/common/json/fetcher/local-json-fetcher.ts
@@ -5,20 +5,23 @@ import { PUBLIC_DIR } from '@/app/common/directories'
 import { appendJsonExtensionIfNeeded } from '@/app/common/json/json-extension-utils'
 import { readJsonSync } from '@/app/common/json/json-file-utils'
 import { REPO_ROOT_DIRECTORY } from '@/app/common/repo-root-directory'
+import { of } from 'rxjs'
 
 export const LOCAL_JSON_FETCHER = new InjectionToken<JsonFetcher>(
   'Local JSON fetcher',
   {
     factory:
       () =>
-      async (...pathSegments: readonly string[]) =>
-        readJsonSync(
-          appendJsonExtensionIfNeeded(
-            join(
-              REPO_ROOT_DIRECTORY,
-              PUBLIC_DIR,
-              JSON_FILES_DIR,
-              ...pathSegments,
+      <T extends object>(...pathSegments: readonly string[]) =>
+        of(
+          readJsonSync<T>(
+            appendJsonExtensionIfNeeded(
+              join(
+                REPO_ROOT_DIRECTORY,
+                PUBLIC_DIR,
+                JSON_FILES_DIR,
+                ...pathSegments,
+              ),
             ),
           ),
         ),

--- a/src/app/projects/project-detail-page/project-detail-page-resolver.service.ts
+++ b/src/app/projects/project-detail-page/project-detail-page-resolver.service.ts
@@ -21,7 +21,7 @@ export class ProjectDetailPageResolver {
       this._navigatorService.displayNotFoundPage()
       return EMPTY
     }
-    return this._projectsService.getDetail(slug!).pipe(
+    return this._projectsService.getDetail(slug).pipe(
       tap({
         error: () => {
           this._navigatorService.displayNotFoundPage()

--- a/src/app/projects/projects-list-page/projects-list-page.component.html
+++ b/src/app/projects/projects-list-page/projects-list-page.component.html
@@ -1,7 +1,7 @@
 @for (item of projects(); track item; let index = $index) {
   <app-project-list-item
     [item]="item"
-    [priority]="index < _maxProjectsPerPage"
+    [priority]="index < _MAX_PROJECTS_PER_PAGE"
     [class.has-preview-images]="item.previewImages && item.previewImages.length"
   ></app-project-list-item>
 }

--- a/src/app/projects/projects-list-page/projects-list-page.component.spec.ts
+++ b/src/app/projects/projects-list-page/projects-list-page.component.spec.ts
@@ -5,6 +5,7 @@ import { MockComponents, MockProvider } from 'ng-mocks'
 import { ProjectListItemComponent } from './project-list-item/project-list-item.component'
 import { ProjectsService } from '../projects.service'
 import { testbedSetup } from '../../../test/testbed-setup'
+import { of } from 'rxjs'
 
 describe('ProjectsListPageComponent', () => {
   let component: ProjectsListPageComponent
@@ -17,9 +18,7 @@ describe('ProjectsListPageComponent', () => {
         imports: [MockComponents(ProjectListItemComponent)],
         providers: [
           MockProvider(ProjectsService, {
-            async getListItems() {
-              return []
-            },
+            getListItems: () => of([]),
           }),
         ],
       },

--- a/src/app/projects/projects-list-page/projects-list-page.component.ts
+++ b/src/app/projects/projects-list-page/projects-list-page.component.ts
@@ -2,7 +2,6 @@ import { Component, Signal } from '@angular/core'
 import { ProjectsService } from '../projects.service'
 import { ProjectListItemComponent } from './project-list-item/project-list-item.component'
 import { toSignal } from '@angular/core/rxjs-interop'
-import { from } from 'rxjs'
 import { ProjectListItem } from '../project'
 
 @Component({
@@ -13,13 +12,10 @@ import { ProjectListItem } from '../project'
 })
 export class ProjectsListPageComponent {
   readonly projects: Signal<readonly ProjectListItem[]>
-  protected readonly _maxProjectsPerPage = 2
+  protected readonly _MAX_PROJECTS_PER_PAGE = 2
 
   constructor(projectsService: ProjectsService) {
-    this.projects = toSignal<
-      readonly ProjectListItem[],
-      readonly ProjectListItem[]
-    >(from(projectsService.getListItems()), {
+    this.projects = toSignal(projectsService.getListItems(), {
       initialValue: [],
     })
   }

--- a/src/app/projects/projects.service.ts
+++ b/src/app/projects/projects.service.ts
@@ -1,18 +1,16 @@
 import { inject, Injectable } from '@angular/core'
 import { JSON_FETCHER } from '@/app/common/json/fetcher/json-fetcher'
 import { PROJECTS_DIR } from '../common/directories'
-import { from, Observable } from 'rxjs'
+import { Observable } from 'rxjs'
 import { ProjectDetail, ProjectListItem } from './project'
 
 @Injectable()
 export class ProjectsService {
   private readonly _jsonFetcher = inject(JSON_FETCHER)
 
-  async getListItems(): Promise<readonly ProjectListItem[]> {
-    return this._jsonFetcher(PROJECTS_DIR)
-  }
+  getListItems = (): Observable<readonly ProjectListItem[]> =>
+    this._jsonFetcher(PROJECTS_DIR)
 
-  getDetail(slug: string): Observable<ProjectDetail> {
-    return from(this._jsonFetcher<ProjectDetail>(PROJECTS_DIR, slug))
-  }
+  getDetail = (slug: string): Observable<ProjectDetail> =>
+    this._jsonFetcher(PROJECTS_DIR, slug)
 }


### PR DESCRIPTION
For consistency. Otherwise projects service was using promises for a project's details but observables for projects list.

Uses observables in JSON fetcher so that less conversions are done around
