### PR TITLE
build: use async JSON read + pending tasks to mark instability

### DIFF
--- a/src/app/common/json/fetcher/local-json-fetcher.ts
+++ b/src/app/common/json/fetcher/local-json-fetcher.ts
@@ -1,29 +1,32 @@
-import { InjectionToken } from '@angular/core'
+import { inject, InjectionToken, PendingTasks } from '@angular/core'
 import { JSON_FILES_DIR, JsonFetcher } from './json-fetcher'
 import { join } from 'path'
 import { PUBLIC_DIR } from '@/app/common/directories'
 import { appendJsonExtensionIfNeeded } from '@/app/common/json/json-extension-utils'
-import { readJsonSync } from '@/app/common/json/json-file-utils'
+import { readJson } from '@/app/common/json/json-file-utils'
 import { REPO_ROOT_DIRECTORY } from '@/app/common/repo-root-directory'
-import { of } from 'rxjs'
+import { from } from 'rxjs'
 
 export const LOCAL_JSON_FETCHER = new InjectionToken<JsonFetcher>(
   'Local JSON fetcher',
   {
-    factory:
-      () =>
-      <T extends object>(...pathSegments: readonly string[]) =>
-        of(
-          readJsonSync<T>(
-            appendJsonExtensionIfNeeded(
-              join(
-                REPO_ROOT_DIRECTORY,
-                PUBLIC_DIR,
-                JSON_FILES_DIR,
-                ...pathSegments,
+    factory: () => {
+      const pendingTasks = inject(PendingTasks)
+      return <T extends object>(...pathSegments: readonly string[]) =>
+        from(
+          pendingTasks.run(() =>
+            readJson<T>(
+              appendJsonExtensionIfNeeded(
+                join(
+                  REPO_ROOT_DIRECTORY,
+                  PUBLIC_DIR,
+                  JSON_FILES_DIR,
+                  ...pathSegments,
+                ),
               ),
             ),
           ),
-        ),
+        )
+    },
   },
 )

--- a/src/app/common/json/json-file-utils.ts
+++ b/src/app/common/json/json-file-utils.ts
@@ -1,5 +1,5 @@
 import { readdir, readFile, writeFile } from 'fs/promises'
-import { Dirent, readFileSync, writeFileSync } from 'fs'
+import { Dirent, writeFileSync } from 'fs'
 import { JSON_EXTENSION } from './json-extension-utils'
 
 const CACHED_JSONS = new Map<string, object>()
@@ -23,8 +23,6 @@ export const readJson = async <T extends object = object>(
   CACHED_JSONS.set(path, json)
   return json as T
 }
-export const readJsonSync = <T extends object>(path: string): T =>
-  CACHED_JSONS.get(path) ?? JSON.parse(readFileSync(path, 'utf-8'))
 
 export const writeJson = async (path: string, data: object): Promise<void> =>
   writeFile(path, stringifyJson(data))


### PR DESCRIPTION
`readFileSync` was used when reading JSONs for prerendering as otherwise the app was marked as stable before the JSON was read. However, the async version can be used. And to mark app instable until async promise resolves, `PendingTasks` can be used. Doesn't use NgZone related utils as the app is now zoneless.
