### PR TITLE
fix: improve project list item scss

### DIFF
--- a/src/app/projects/images-swiper/images-swiper.component.scss
+++ b/src/app/projects/images-swiper/images-swiper.component.scss
@@ -7,16 +7,15 @@ swiper-container {
   white-space: nowrap;
   // 👇 If scroll, weird blue box appears even after Swiper.js inits
   overflow: hidden;
-  // 👇 For portrait images.
-  //    Applying it here instead of image/slide so that:
-  //     - Can see layout when no images inside
-  //     - Slide doesn't overflow container height
-  max-height: calc(100vh - #{logo.$height});
 }
 
 swiper-slide {
   // 👇 To size a slide. See HTML to see why needs to be sized.
   display: inline-block;
+  // 👇 For portrait images.
+  //    Applying it here instead of image so that layout can be seen
+  //    when no images inside.
+  max-height: calc(100vh - #{logo.$height});
 }
 
 img {

--- a/src/app/projects/projects-list-page/project-list-item/project-list-item.component.scss
+++ b/src/app/projects/projects-list-page/project-list-item/project-list-item.component.scss
@@ -17,18 +17,17 @@
   gap: margins.$l;
 }
 
-$texts-width-big-screen: 400px; // ~50ch
 .texts {
   display: flex;
   flex-direction: column;
+  flex: 1 0 50ch;
 }
 
 app-images-swiper {
-  // 👇 Keep in sync with component responsive images
-  // 👇 Seems Swiper.js needs size set to work fine
-  width: calc(
-    100vw - $texts-width-big-screen - #{(page.$padding-horizontal * 2)}
-  );
+  // 👇 Needed for Swiper.js to properly calculate width in a flex container
+  //    https://github.com/nolimits4web/swiper/issues/2361#issuecomment-348208353
+  min-width: 0;
+  width: 100%;
 }
 
 @include breakpoints.until(breakpoints.$m) {
@@ -39,12 +38,11 @@ app-images-swiper {
 
   .texts {
     order: 2;
-    max-width: unset;
+    flex-shrink: 1;
   }
 
   // 👇 Keep in sync with component responsive images
   app-images-swiper {
-    width: 100%;
     order: 1;
   }
 }

--- a/src/app/projects/projects-list-page/projects-list-page.component.scss
+++ b/src/app/projects/projects-list-page/projects-list-page.component.scss
@@ -5,16 +5,6 @@
   @include page.padding;
 
   display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
+  flex-direction: column;
   gap: margins.$l;
-}
-
-app-project-list-item {
-  flex: 1;
-
-  &.has-preview-images {
-    flex: unset;
-    max-width: 100%;
-  }
 }


### PR DESCRIPTION
After quick check on live site, seems there have been some regressions:
 - On desktop, layout when Swiper.js wasn't loaded yet was incorrect. Text was taking most of screen. Seems `width` of `app-images-swiper` wasn't being taken into account due to flexbox. [To solve this and also avoid specifying width with calc + taking into account page padding and text width, using `min-width: 0`](https://github.com/nolimits4web/swiper/issues/2361). This way only the text width is set. Then the swiper takes the rest of space. `min-width` is important as otherwise Swiper.js doesn't calculate the width properly. Setting text to grow but not shrink on large screens so that it's `50ch` in that scenario. For smaller screens, adding `flex-shrink` to avoid `50ch` from overflowing. Removing duplicate `width: 100%` of images app swiper.
 - Moving `max-height` to swiper slide. Otherwise the slide was taking more height than `swiper-container`. Though `swiper-container` wasn't overflowing due to that constraint. Hence part of the image was lost. If moving that to the slide, it takes proper height and doesn't overflow. Not sure why it was overflowing before.
 - Removing unneeded CSS for project list page. The scenario of no preview images won't be taken into account for now.
