### PR TITLE
perf: use Swiper.js core instead of element

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -48,14 +48,7 @@
             "stylePreprocessorOptions": {
               "includePaths": ["src/sass"]
             },
-            "styles": [
-              "src/styles.scss",
-              {
-                "input": "src/swiper.scss",
-                "inject": false,
-                "bundleName": "swiper"
-              }
-            ],
+            "styles": ["src/styles.scss"],
             "scripts": [],
             "browser": "src/main.ts",
             "server": "src/main.server.ts",
@@ -73,7 +66,7 @@
                 {
                   "type": "anyComponentStyle",
                   "maximumWarning": "2kb",
-                  "maximumError": "4kb"
+                  "maximumError": "14kb"
                 }
               ],
               "outputHashing": "all"
@@ -119,14 +112,7 @@
             "stylePreprocessorOptions": {
               "includePaths": ["src/sass"]
             },
-            "styles": [
-              "src/styles.scss",
-              {
-                "input": "src/swiper.scss",
-                "inject": false,
-                "bundleName": "swiper"
-              }
-            ],
+            "styles": ["src/styles.scss"],
             "scripts": []
           }
         },

--- a/src/app/projects/images-swiper/images-swiper.component.html
+++ b/src/app/projects/images-swiper/images-swiper.component.html
@@ -1,17 +1,9 @@
-@if (images().length) {
-  <!-- 👇 Avoid layout shift https://github.com/davidlj95/chrislb/pull/643 -->
-  <!--    Applying it to slide would be enough if Swiper.js didn't rewrite their HTML -->
-  @let firstImage = images()[0];
-  @let aspectRatio = (firstImage.width * slidesPerView()) / firstImage.height;
-  <swiper-container
-    [appSwiper]="_swiperOptions()"
-    appSwiperAutoplayScroll
-    init="false"
-    [style.aspect-ratio]="fixContainerAspectRatio() ? aspectRatio : undefined"
-  >
+<div class="swiper" [appSwiper]="_swiperOptions()" appSwiperAutoplayScroll>
+  <div class="swiper-wrapper">
     @for (image of _imageViewModels(); track image) {
-      <!-- 👇 Base layout until Swiper.js initializes -->
-      <swiper-slide
+      <!-- 👇 Styles for base layout until Swiper.js initializes -->
+      <div
+        class="swiper-slide"
         [style.width.%]="100 / slidesPerView()"
         [style.aspect-ratio]="image.width / image.height"
       >
@@ -26,7 +18,10 @@
           [attr.loading]="image.loading"
           [attr.fetchpriority]="image.fetchPriority"
         />
-      </swiper-slide>
+      </div>
     }
-  </swiper-container>
-}
+  </div>
+  <div class="swiper-pagination"></div>
+  <div class="swiper-button-prev"></div>
+  <div class="swiper-button-next"></div>
+</div>

--- a/src/app/projects/images-swiper/images-swiper.component.scss
+++ b/src/app/projects/images-swiper/images-swiper.component.scss
@@ -1,17 +1,21 @@
 @use 'logo';
 @use 'theme';
 
-swiper-container {
-  display: block;
-  // 👇 If Swiper.js isn't there it'd display as an horizontal list of slides
-  white-space: nowrap;
-  // 👇 If scroll, weird blue box appears even after Swiper.js inits
-  overflow: hidden;
+@forward 'swiper/scss';
+@forward 'swiper/scss/a11y';
+@forward 'swiper/scss/autoplay';
+@forward 'swiper/scss/keyboard';
+@forward 'swiper/scss/navigation';
+@forward 'swiper/scss/pagination';
+@forward 'swiper/scss/virtual';
+
+@at-root {
+  :root {
+    --swiper-theme-color: #{theme.$accent};
+  }
 }
 
-swiper-slide {
-  // 👇 To size a slide. See HTML to see why needs to be sized.
-  display: inline-block;
+.swiper-slide {
   // 👇 For portrait images.
   //    Applying it here instead of image so that layout can be seen
   //    when no images inside.
@@ -21,17 +25,4 @@ swiper-slide {
 img {
   object-fit: contain;
   max-height: 100%;
-}
-
-$balanced-luminance-color: theme.$accent;
-
-swiper-container::part(button-prev),
-swiper-container::part(button-next) {
-  position: absolute; // perf trick 2 avoid layout shifts
-  color: $balanced-luminance-color;
-}
-
-swiper-container::part(bullet-active),
-swiper-container::part(bullet) {
-  background-color: $balanced-luminance-color;
 }

--- a/src/app/projects/images-swiper/images-swiper.component.spec.ts
+++ b/src/app/projects/images-swiper/images-swiper.component.spec.ts
@@ -11,6 +11,8 @@ describe('ImagesSwiperComponent', () => {
     testbedSetup()
     fixture = TestBed.createComponent(ImagesSwiperComponent)
     fixture.componentRef.setInput('images', [])
+    fixture.componentRef.setInput('sizes', '')
+    fixture.componentRef.setInput('slidesPerView', 2)
     component = fixture.componentInstance
     fixture.detectChanges()
   })

--- a/src/app/projects/images-swiper/images-swiper.component.ts
+++ b/src/app/projects/images-swiper/images-swiper.component.ts
@@ -1,9 +1,9 @@
 import {
   Component,
   computed,
-  CUSTOM_ELEMENTS_SCHEMA,
   inject,
   input,
+  ViewEncapsulation,
 } from '@angular/core'
 import { SwiperOptions } from 'swiper/types'
 import {
@@ -19,24 +19,20 @@ import { SwiperDirective } from './swiper.directive'
 import { IMAGE_LOADER, ImageLoader, ImageLoaderConfig } from '@angular/common'
 import { unsignedBreakpoints } from '@/app/common/images/to-ng-src-set'
 import { toLoaderParams } from '@/app/common/images/to-loader-params'
-import { SwiperAutoplayScrollDirective } from '@/app/projects/images-swiper/swiper-autoplay-scroll.directive'
+import { SwiperAutoplayScrollDirective } from './swiper-autoplay-scroll.directive'
 
 @Component({
   selector: 'app-images-swiper',
   templateUrl: './images-swiper.component.html',
   styleUrls: ['./images-swiper.component.scss'],
+  encapsulation: ViewEncapsulation.None,
   imports: [SwiperDirective, SwiperAutoplayScrollDirective],
-  // Use swiper web components
-  // A better approach would be to declare those but there's no easy way
-  // https://stackoverflow.com/a/43012920/3263250
-  schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
 export class ImagesSwiperComponent {
   readonly images = input.required<readonly ResponsiveImage[]>()
   readonly sizes = input.required<string>()
   readonly slidesPerView = input.required<number>()
   readonly priority = input(false)
-  readonly fixContainerAspectRatio = input(false)
   protected readonly _swiperOptions = computed<SwiperOptions>(() => ({
     ...DEFAULT_SWIPER_OPTIONS,
     slidesPerView: this.slidesPerView(),
@@ -87,9 +83,12 @@ const DEFAULT_SWIPER_OPTIONS = {
   },
   navigation: {
     enabled: true,
+    nextEl: '.swiper-button-next',
+    prevEl: '.swiper-button-prev',
   },
   pagination: {
     enabled: true,
+    el: '.swiper-pagination',
     clickable: true,
     dynamicBullets: true,
   },

--- a/src/app/projects/images-swiper/swiper.directive.ts
+++ b/src/app/projects/images-swiper/swiper.directive.ts
@@ -2,7 +2,9 @@ import {
   Directive,
   effect,
   ElementRef,
+  inject,
   Inject,
+  InjectionToken,
   input,
   OnDestroy,
   PLATFORM_ID,
@@ -17,12 +19,12 @@ export class SwiperDirective implements OnDestroy {
   instance?: Swiper
 
   constructor(
+    @Inject(SWIPER_JS) swiperJs: typeof Swiper,
     elRef: ElementRef<HTMLElement>,
-    @Inject(PLATFORM_ID) platformId: object,
   ) {
     effect(() => {
-      if (!this.instance && isPlatformBrowser(platformId)) {
-        this.instance = new Swiper(elRef.nativeElement, this.options())
+      if (swiperJs && !this.instance) {
+        this.instance = new swiperJs(elRef.nativeElement, this.options())
       }
     })
   }
@@ -31,3 +33,8 @@ export class SwiperDirective implements OnDestroy {
     this.instance?.destroy()
   }
 }
+
+// @visibleForTesting
+export const SWIPER_JS = new InjectionToken<typeof Swiper | null>('Swiper.js', {
+  factory: () => (isPlatformBrowser(inject(PLATFORM_ID)) ? Swiper : null),
+})

--- a/src/app/projects/images-swiper/swiper.directive.ts
+++ b/src/app/projects/images-swiper/swiper.directive.ts
@@ -1,27 +1,33 @@
 import {
-  register as registerSwiper,
-  type SwiperContainer,
-} from 'swiper/element'
-import { Directive, effect, ElementRef, input } from '@angular/core'
+  Directive,
+  effect,
+  ElementRef,
+  Inject,
+  input,
+  OnDestroy,
+  PLATFORM_ID,
+} from '@angular/core'
 import { SwiperOptions } from 'swiper/types'
-
-// There's no fancier way to install Web Components in Angular :P
-// https://stackoverflow.com/a/75353889/3263250
-registerSwiper()
+import Swiper from 'swiper'
+import { isPlatformBrowser } from '@angular/common'
 
 @Directive({ selector: '[appSwiper]' })
-export class SwiperDirective {
+export class SwiperDirective implements OnDestroy {
   readonly options = input.required<SwiperOptions>({ alias: 'appSwiper' })
+  instance?: Swiper
 
-  constructor(elRef: ElementRef<Element & Partial<SwiperContainer>>) {
+  constructor(
+    elRef: ElementRef<HTMLElement>,
+    @Inject(PLATFORM_ID) platformId: object,
+  ) {
     effect(() => {
-      const element = elRef.nativeElement
-      const initializer = element.initialize
-      if (initializer) {
-        Object.assign(element, this.options())
-        //👇 If app wasn't zone-less, would use NgZone.runOutsideAngular
-        initializer.bind(element)()
+      if (!this.instance && isPlatformBrowser(platformId)) {
+        this.instance = new Swiper(elRef.nativeElement, this.options())
       }
     })
+  }
+
+  ngOnDestroy() {
+    this.instance?.destroy()
   }
 }

--- a/src/app/projects/images-swiper/swiper.directive.ts
+++ b/src/app/projects/images-swiper/swiper.directive.ts
@@ -1,12 +1,12 @@
 import {
   Directive,
-  effect,
   ElementRef,
   inject,
   Inject,
   InjectionToken,
   input,
   OnDestroy,
+  OnInit,
   PLATFORM_ID,
 } from '@angular/core'
 import { SwiperOptions } from 'swiper/types'
@@ -14,19 +14,22 @@ import Swiper from 'swiper'
 import { isPlatformBrowser } from '@angular/common'
 
 @Directive({ selector: '[appSwiper]' })
-export class SwiperDirective implements OnDestroy {
+export class SwiperDirective implements OnInit, OnDestroy {
   readonly options = input.required<SwiperOptions>({ alias: 'appSwiper' })
   instance?: Swiper
 
   constructor(
-    @Inject(SWIPER_JS) swiperJs: typeof Swiper,
-    elRef: ElementRef<HTMLElement>,
-  ) {
-    effect(() => {
-      if (swiperJs && !this.instance) {
-        this.instance = new swiperJs(elRef.nativeElement, this.options())
-      }
-    })
+    @Inject(SWIPER_JS) private readonly _swiperJs: typeof Swiper,
+    private readonly _elRef: ElementRef<HTMLElement>,
+  ) {}
+
+  ngOnInit(): void {
+    if (this._swiperJs && !this.instance) {
+      this.instance = new this._swiperJs(
+        this._elRef.nativeElement,
+        this.options(),
+      )
+    }
   }
 
   ngOnDestroy() {

--- a/src/app/projects/project-detail-page/project-detail-page.component.html
+++ b/src/app/projects/project-detail-page/project-detail-page.component.html
@@ -22,7 +22,6 @@
       [slidesPerView]="album.slidesPerView"
       [style.max-width.px]="album.maxWidthPx"
       [priority]="index < _maxSwipersPerViewport"
-      [fixContainerAspectRatio]="true"
     ></app-images-swiper>
   </div>
 }

--- a/src/swiper.scss
+++ b/src/swiper.scss
@@ -1,5 +1,0 @@
-@forward 'swiper/element/css/a11y';
-@forward 'swiper/element/css/autoplay';
-@forward 'swiper/element/css/keyboard';
-@forward 'swiper/element/css/navigation';
-@forward 'swiper/element/css/pagination';


### PR DESCRIPTION
Swiper Element is nice because it adds isolation to styles and magically creates navigation & pagination amongst others without having to code them yourself. However, it has also some drawbacks:
 - CSS styles are loaded by JS. So they can't be inlined. Which adds a bit of delay to render the swiper. Given the swiper is part of the FCP & LCP, it's a considerable time win.
 - Registering the web component takes some time. Which delays rendering. Plus also
 - Due to HTML rewrite when the web component initializes, some of the performance tricks to avoid layout shifts are trickier. Because the HTML will be rewritten by Swiper Element, losing some of those tweaks. So had to introduce the `fixAspectRatio` input to images swiper to add an uglier tweak to workaround that.
 
So we win in performance! Only thing losing here is that component style budget has been raised to 14kBs error. As there are lots of CSS for the Swiper.

> The drawback for now is that styles are now not encapsulated. As given that Swiper.js will write some HTML, if they are encapsulated, they won't apply to elements not created by Angular. Another option would be to mark those styles as `::ng-deep` but not sure how with SCSS. Didn't manage to use `::ng-deep` + `@forward`. Seems [SASS' `meta.load-css`](https://sass-lang.com/documentation/modules/meta/#load-css) can be useful. Will take a look after this PR.
