### PR TITLE
(test): try out auto `auto` sizes with Swiper.js core + virtual SCSS

### DIFF
--- a/src/app/projects/images-swiper/images-swiper.component.html
+++ b/src/app/projects/images-swiper/images-swiper.component.html
@@ -1,22 +1,21 @@
 <div class="swiper" [appSwiper]="_swiperOptions()" appSwiperAutoplayScroll>
   <div class="swiper-wrapper">
-    @for (image of _imageViewModels(); track image) {
+    @for (image of images(); track image) {
       <!-- 👇 Styles for base layout until Swiper.js initializes -->
       <div
         class="swiper-slide"
         [style.width.%]="100 / slidesPerView()"
         [style.aspect-ratio]="image.width / image.height"
       >
-        <!--suppress AngularNgOptimizedImage - Can't use due to auto `auto` sizes -->
         <img
-          [src]="image.src"
+          [ngSrc]="image.src"
           [width]="image.width"
           [height]="image.height"
           [alt]="image.alt"
-          [srcset]="image.srcset"
-          [sizes]="image.sizes"
-          [attr.loading]="image.loading"
-          [attr.fetchpriority]="image.fetchPriority"
+          [ngSrcset]="image.breakpoints | toNgSrcSet"
+          [sizes]="sizes()"
+          [priority]="priority() && $index < slidesPerView()"
+          [loaderParams]="image | toLoaderParams"
         />
       </div>
     }

--- a/src/app/projects/images-swiper/images-swiper.component.ts
+++ b/src/app/projects/images-swiper/images-swiper.component.ts
@@ -16,9 +16,20 @@ import {
 } from 'swiper/modules'
 import { ResponsiveImage } from '../../common/images/image'
 import { SwiperDirective } from './swiper.directive'
-import { IMAGE_LOADER, ImageLoader, ImageLoaderConfig } from '@angular/common'
-import { unsignedBreakpoints } from '@/app/common/images/to-ng-src-set'
-import { toLoaderParams } from '@/app/common/images/to-loader-params'
+import {
+  IMAGE_LOADER,
+  ImageLoader,
+  ImageLoaderConfig,
+  NgOptimizedImage,
+} from '@angular/common'
+import {
+  ToNgSrcSet,
+  unsignedBreakpoints,
+} from '@/app/common/images/to-ng-src-set'
+import {
+  ToLoaderParams,
+  toLoaderParams,
+} from '@/app/common/images/to-loader-params'
 import { SwiperAutoplayScrollDirective } from './swiper-autoplay-scroll.directive'
 
 @Component({
@@ -26,7 +37,13 @@ import { SwiperAutoplayScrollDirective } from './swiper-autoplay-scroll.directiv
   templateUrl: './images-swiper.component.html',
   styleUrls: ['./images-swiper.component.scss'],
   encapsulation: ViewEncapsulation.None,
-  imports: [SwiperDirective, SwiperAutoplayScrollDirective],
+  imports: [
+    SwiperDirective,
+    SwiperAutoplayScrollDirective,
+    NgOptimizedImage,
+    ToNgSrcSet,
+    ToLoaderParams,
+  ],
 })
 export class ImagesSwiperComponent {
   readonly images = input.required<readonly ResponsiveImage[]>()


### PR DESCRIPTION
In #667 when migrating from Swiper.js Element to core, noticed a detail. The `virtual` CSS styles were not added. Trying what happens after adding them. Just in case now the `auto` in `sizes` can be calculated properly.
