### PR TITLE
feat: improve project list item sizes

### DIFF
--- a/scripts/src/images/models/css-length.ts
+++ b/scripts/src/images/models/css-length.ts
@@ -12,16 +12,20 @@ export class CssLength<U extends CssUnit = CssUnit> {
   }
 }
 
-export type CssUnit = typeof CSS_PX_UNIT | typeof CSS_VW_UNIT
+export type CssUnit =
+  | typeof CSS_PX_UNIT
+  | typeof CSS_VW_UNIT
+  | typeof CSS_VH_UNIT
 export const CSS_PX_UNIT = 'px'
 export const CSS_VW_UNIT = 'vw'
+export const CSS_VH_UNIT = 'vh'
+
+export type HorizontalCssUnit = typeof CSS_VW_UNIT | typeof CSS_PX_UNIT
+export type HorizontalCssLength = CssLength<HorizontalCssUnit>
+
+export type VerticalCssUnit = typeof CSS_VH_UNIT | typeof CSS_PX_UNIT
+export type VerticalCssLength = CssLength<VerticalCssUnit>
 
 export const Px = (quantity: number) => new CssLength(quantity, CSS_PX_UNIT)
-export const Vw = (quantity: number) => {
-  if (quantity < 0 || quantity > 100) {
-    throw new Error(
-      `Invalid ${quantity} ${CSS_VW_UNIT} quantity: must be > 0 and <= 100`,
-    )
-  }
-  return new CssLength(quantity, CSS_VW_UNIT)
-}
+export const Vw = (quantity: number) => new CssLength(quantity, CSS_VW_UNIT)
+export const Vh = (quantity: number) => new CssLength(quantity, CSS_VH_UNIT)

--- a/scripts/src/images/models/css-media-condition.ts
+++ b/scripts/src/images/models/css-media-condition.ts
@@ -17,12 +17,15 @@ export const MAX_LIMIT = 'max'
 type Limit = typeof MIN_LIMIT | typeof MAX_LIMIT
 
 const WIDTH_DIMENSION = 'width'
-type Dimension = typeof WIDTH_DIMENSION
+const HEIGHT_DIMENSION = 'height'
+type Dimension = typeof WIDTH_DIMENSION | typeof HEIGHT_DIMENSION
 
 export const minWidth = (px: number) =>
   new CssPxLimitMediaCondition(MIN_LIMIT, WIDTH_DIMENSION, Px(px))
 export const maxWidth = (px: number) =>
   new CssPxLimitMediaCondition(MAX_LIMIT, WIDTH_DIMENSION, Px(px))
+export const maxHeight = (px: number) =>
+  new CssPxLimitMediaCondition(MAX_LIMIT, HEIGHT_DIMENSION, Px(px))
 
 export const invertMediaConditionMinMax = (
   mediaCondition: CssPxLimitMediaCondition,

--- a/scripts/src/images/models/source-size-list.test.ts
+++ b/scripts/src/images/models/source-size-list.test.ts
@@ -1,12 +1,13 @@
 import { describe, it } from 'node:test'
 import { strictEqual } from 'node:assert'
 import { sourceSizeList } from './source-size-list'
-import { SourceSize } from './source-size'
+import { WidthSourceSize } from './source-size'
+import { PROJECT_LIST_ITEM } from '../sizes'
 
 describe('Source size list', () => {
   const SOURCE_SIZE_LIST = sourceSizeList(
-    { toString: () => 'sourceSizeA', mediaCondition: {} } as SourceSize,
-    { toString: () => 'sourceSizeB' } as SourceSize,
+    { toString: () => 'sourceSizeA', mediaCondition: {} } as WidthSourceSize,
+    { toString: () => 'sourceSizeB' } as WidthSourceSize,
   )
 
   it('should join sizes by comma when representing it as a string', () => {
@@ -14,5 +15,10 @@ describe('Source size list', () => {
       SOURCE_SIZE_LIST.toString(),
       `${SOURCE_SIZE_LIST.sizes[0].toString()},${SOURCE_SIZE_LIST.sizes[1].toString()}`,
     )
+  })
+
+  it('should calculate properly height sizes', () => {
+    const actual = PROJECT_LIST_ITEM.toString()
+    strictEqual(actual, 'foo')
   })
 })

--- a/scripts/src/images/models/source-size-list.ts
+++ b/scripts/src/images/models/source-size-list.ts
@@ -1,15 +1,31 @@
-import { SourceSize } from './source-size'
+import {
+  isHeightSourceSize,
+  isWidthSourceSize,
+  SourceSize,
+} from './source-size'
 
 export class SourceSizeList {
   constructor(readonly sizes: readonly SourceSize[]) {
     if (sizes.length === 0) {
       throw new Error('At least one size must be specified')
     }
-    if (sizes.slice(0, -1).some((size) => !size.mediaCondition)) {
-      throw new Error('All but last size must have a media condition')
+    if (
+      sizes
+        .slice(0, -1)
+        .some((size) => isWidthSourceSize(size) && !size.mediaCondition)
+    ) {
+      throw new Error(
+        'All but last size must specify widths and have a media condition',
+      )
     }
-    if (sizes.at(-1)!.mediaCondition) {
+    const lastSourceSize = sizes.at(-1)!
+
+    if (isWidthSourceSize(lastSourceSize) && lastSourceSize.mediaCondition) {
       throw new Error('Last size must not have a media condition')
+    }
+
+    if (isHeightSourceSize(lastSourceSize)) {
+      lastSourceSize.sourceSizeList = this
     }
   }
 

--- a/scripts/src/images/models/source-size.ts
+++ b/scripts/src/images/models/source-size.ts
@@ -1,10 +1,36 @@
-import { CssLength } from './css-length'
-import { CssPxLimitMediaCondition } from './css-media-condition'
+import {
+  RESOLUTIONS,
+  resolutionWidthMatchesMediaCondition,
+} from '../responsive/resolutions'
+import {
+  CSS_PX_UNIT,
+  CSS_VH_UNIT,
+  CSS_VW_UNIT,
+  CssLength,
+  HorizontalCssLength,
+  Px,
+  VerticalCssLength,
+} from './css-length'
+import { CssPxLimitMediaCondition, maxHeight } from './css-media-condition'
+import { SourceSizeList } from './source-size-list'
+
+export type SourceSize = WidthSourceSize | HeightSourceSize
+
+interface SourceSizeBase {
+  readonly length: OneOrMore<CssLength>
+  readonly side: SourceSizeSide
+}
+
+const SOURCE_SIZE_WIDTH = 'w'
+const SOURCE_SIZE_HEIGHT = 'h'
+type SourceSizeSide = typeof SOURCE_SIZE_WIDTH | typeof SOURCE_SIZE_HEIGHT
 
 // https://html.spec.whatwg.org/multipage/images.html#sizes-attribute
-export class SourceSize {
+export class WidthSourceSize implements SourceSizeBase {
+  readonly side = SOURCE_SIZE_WIDTH
+
   constructor(
-    readonly length: CssLength | readonly CssLength[], // | 'auto'
+    readonly length: OneOrMore<HorizontalCssLength>,
     readonly mediaCondition?: CssPxLimitMediaCondition,
   ) {}
 
@@ -17,8 +43,8 @@ export class SourceSize {
   }
 }
 
-const lengthAsString = (lengthOrLengths: SourceSize['length']): string => {
-  if (!(Array.isArray as isCssLengthArray)(lengthOrLengths)) {
+const lengthAsString = (lengthOrLengths: WidthSourceSize['length']): string => {
+  if (!isArray(lengthOrLengths)) {
     return lengthOrLengths.toString()
   }
   const parts = lengthOrLengths
@@ -31,11 +57,92 @@ const lengthAsString = (lengthOrLengths: SourceSize['length']): string => {
   return `calc(${parts.join(' ')})`
 }
 
-type isCssLengthArray = (
-  lengthOrLengths: SourceSize['length'],
-) => lengthOrLengths is readonly CssLength[]
+const isArray = <T>(oneOrMore: OneOrMore<T>): oneOrMore is readonly T[] =>
+  Array.isArray(oneOrMore)
+
+export type OneOrMore<T> = T | readonly T[]
 
 export const sourceSize = (
+  length: WidthSourceSize['length'],
+  mediaCondition?: WidthSourceSize['mediaCondition'],
+) => new WidthSourceSize(length, mediaCondition)
+
+export const lengthToPx = (
   length: SourceSize['length'],
-  mediaCondition?: SourceSize['mediaCondition'],
-) => new SourceSize(length, mediaCondition)
+  viewportPx: number,
+): number =>
+  (Array.isArray(length) ? length : [length]).reduce<number>(
+    (accumulator, length) => accumulator + singleLengthToPx(length, viewportPx),
+    0,
+  )
+
+export const singleLengthToPx = (
+  length: CssLength,
+  viewportPx: number,
+): number => {
+  switch (length.unit) {
+    case CSS_PX_UNIT:
+      return length.quantity
+    case CSS_VW_UNIT:
+    case CSS_VH_UNIT:
+      return Math.ceil((viewportPx * length.quantity) / 100)
+  }
+}
+
+export const isWidthSourceSize = (
+  sourceSize: SourceSize,
+): sourceSize is WidthSourceSize => sourceSize.side === SOURCE_SIZE_WIDTH
+
+export class HeightSourceSize implements SourceSizeBase {
+  readonly side = SOURCE_SIZE_HEIGHT
+  sourceSizeList?: SourceSizeList
+
+  constructor(
+    readonly length: VerticalCssLength | readonly VerticalCssLength[], // | 'auto'
+  ) {}
+
+  toString(): string {
+    if (!this.sourceSizeList) {
+      throw new Error(
+        'A height source size must be inside a source size list to be serialized',
+      )
+    }
+    const previousWidthSourceSizes =
+      this.sourceSizeList.sizes.filter(isWidthSourceSize)
+    const remainingResolutions = [...RESOLUTIONS]
+    for (const size of previousWidthSourceSizes) {
+      let removedItems = 0
+      remainingResolutions.forEach((resolution, index) => {
+        if (
+          resolutionWidthMatchesMediaCondition(
+            resolution.width,
+            size.mediaCondition,
+          )
+        ) {
+          remainingResolutions.splice(index - removedItems, 1)
+          removedItems += 1
+        }
+      })
+    }
+    const remainingResolutionsSortedByHeight = remainingResolutions.sort(
+      (resA, resB) => resA.height - resB.height,
+    )
+    const maxHeightAndWidth = remainingResolutionsSortedByHeight.map(
+      (resolution) => {
+        const imageHeightPx = lengthToPx(this.length, resolution.height)
+        const imageWidthPx = imageHeightPx * 1 // ASPECT_RATIOOOOOR
+        return [maxHeight(resolution.height), Px(imageWidthPx)] as const
+      },
+    )
+    return maxHeightAndWidth
+      .map(([maxHeight, widthPx]) => [maxHeight.toString(), widthPx].join(' '))
+      .join(',')
+  }
+}
+
+export const isHeightSourceSize = (
+  sourceSize: SourceSize,
+): sourceSize is HeightSourceSize => sourceSize.side === SOURCE_SIZE_HEIGHT
+
+export const heightSourceSize = (length: HeightSourceSize['length']) =>
+  new HeightSourceSize(length)

--- a/scripts/src/images/responsive/breakpoints-from-sizes-and-dimensions.test.ts
+++ b/scripts/src/images/responsive/breakpoints-from-sizes-and-dimensions.test.ts
@@ -1,22 +1,20 @@
 import { describe, it } from 'node:test'
 import { SourceSizeList } from '../models/source-size-list'
-import {
-  breakpointsFromSizesAndDimensions,
-  MOBILE_RESOLUTION_WIDTHS,
-} from './breakpoints-from-sizes-and-dimensions'
+import { breakpointsFromSizesAndDimensions } from './breakpoints-from-sizes-and-dimensions'
 import { sourceSize } from '../models/source-size'
 import { Px, Vw } from '../models/css-length'
 import assert from 'node:assert'
 import * as SIZES_IMPORT from '../sizes'
 import { PROJECT_DETAIL_BY_PRESET_SIZE } from '../sizes'
 import { ImageDimensions } from '@/app/common/images/image'
+import { RESOLUTIONS } from './resolutions'
 
 describe('Breakpoints from sizes and dimensions', () => {
   const SAMPLE_IMAGE_DIMENSIONS: ImageDimensions = {
     width: 3240,
     height: 2160,
   }
-  const MIN_RES_WIDTH = Math.min(...MOBILE_RESOLUTION_WIDTHS)
+  const MIN_RES_WIDTH = Math.min(...RESOLUTIONS.map(({ width }) => width))
   const sut = breakpointsFromSizesAndDimensions
 
   it('should return high density breakpoints whilst respecting max width query', () => {

--- a/scripts/src/images/responsive/resolutions.ts
+++ b/scripts/src/images/responsive/resolutions.ts
@@ -1,0 +1,84 @@
+import { ImageDimensions } from '@/app/common/images/image'
+import { WidthSourceSize } from '../models/source-size'
+import { MAX_LIMIT, MIN_LIMIT } from '../models/css-media-condition'
+
+type RawDimensions = [number, number] // [width, height]
+// Filters them so there's only 1 per width
+// Transforms them into objects
+const resolutionsFromRawDimensions = (
+  rawDimensions: readonly RawDimensions[],
+): readonly ImageDimensions[] =>
+  Object.entries(Object.fromEntries(rawDimensions))
+    .map(([width, height]) => [parseInt(width), height])
+    .map(([width, height]) => ({ width, height }))
+
+// Despite they are high density screens, so browsers will probably use
+// bigger images. Will calculate 1x, 2x, 3x for each one though.
+// @visibleForTesting
+const MOBILE_RESOLUTIONS = resolutionsFromRawDimensions([
+  // 👇 Obtained from
+  //    https://gs.statcounter.com/screen-resolution-stats/mobile/worldwide
+  [360, 800],
+  // [390, 844], // Too similar
+  // [393, 873], // Too similar
+  // [412, 915], // Too similar
+  // [375, 812], // Too similar
+  // [393, 852], // Too similar
+
+  // 👇 Obtained from
+  // https://www.browserstack.com/guide/common-screen-resolutions
+  [360, 800],
+  // [390, 844], // Too similar
+  // [393, 873], // Too similar
+  // [412, 915], // Too similar
+  // [414, 896], // Too similar
+  // [360, 780], // Too similar
+
+  // 👇 For Lighthouse, as performs tests on a Moto G Power (412x823)
+  // https://github.com/GoogleChrome/lighthouse/blob/v12.5.1/core/config/constants.js#L11-L22
+  [412, 823],
+])
+export const MAX_MOBILE_RESOLUTION_WIDTH = Math.max(
+  ...MOBILE_RESOLUTIONS.map(({ width }) => width),
+)
+
+const DESKTOP_RESOLUTIONS = resolutionsFromRawDimensions([
+  // 👇 Obtained from
+  //    https://gs.statcounter.com/screen-resolution-stats/desktop/worldwide
+  [1920, 1080],
+  [1536, 864],
+  [1366, 768],
+  [1280, 720],
+  [1440, 900],
+  [2560, 1440],
+  // 👇 Obtained from
+  //    https://www.browserstack.com/guide/common-screen-resolutions
+  [1920, 1080],
+  [1366, 768],
+  [1536, 864],
+  [1280, 720],
+  [1440, 900],
+  [1600, 1900],
+])
+
+export const RESOLUTIONS: readonly ImageDimensions[] = [
+  ...MOBILE_RESOLUTIONS,
+  ...DESKTOP_RESOLUTIONS,
+].sort((resolutionA, resolutionB) => resolutionA.width - resolutionB.width)
+
+export const MAX_RESOLUTION_WIDTH = Math.max(
+  ...RESOLUTIONS.map(({ width }) => width),
+)
+
+export const resolutionWidthMatchesMediaCondition = (
+  resolutionWidth: number,
+  mediaCondition: WidthSourceSize['mediaCondition'],
+): boolean => {
+  if (!mediaCondition) return true
+  switch (mediaCondition.limit) {
+    case MIN_LIMIT:
+      return resolutionWidth >= mediaCondition.length.quantity
+    case MAX_LIMIT:
+      return resolutionWidth <= mediaCondition.length.quantity
+  }
+}

--- a/scripts/src/images/sizes.ts
+++ b/scripts/src/images/sizes.ts
@@ -1,6 +1,10 @@
 import { SourceSizeList, sourceSizeList } from './models/source-size-list'
-import { SourceSize, sourceSize } from './models/source-size'
-import { Px, Vw } from './models/css-length'
+import {
+  heightSourceSize,
+  sourceSize,
+  WidthSourceSize,
+} from './models/source-size'
+import { Px, Vh, Vw } from './models/css-length'
 import { maxWidth, minWidth } from './models/css-media-condition'
 import {
   BREAKPOINT_M_PX,
@@ -17,9 +21,9 @@ import { HORIZONTAL_PAGE_PADDING_PX } from '@/app/common/paddings'
 const horizontalPagePadding = (divider = 1) =>
   Px(HORIZONTAL_PAGE_PADDING_PX / divider)
 const withHorizontalPagePadding = (
-  length: SourceSize['length'],
+  length: WidthSourceSize['length'],
   divider = 1,
-): SourceSize['length'] => {
+): WidthSourceSize['length'] => {
   const padding = horizontalPagePadding(divider)
   return padding.quantity === 0
     ? length
@@ -28,9 +32,9 @@ const withHorizontalPagePadding = (
       : [length, padding]
 }
 const withoutHorizontalPagePadding = (
-  length: SourceSize['length'],
+  length: WidthSourceSize['length'],
   divider = 1,
-): SourceSize['length'] => withHorizontalPagePadding(length, divider * -1)
+): WidthSourceSize['length'] => withHorizontalPagePadding(length, divider * -1)
 
 export const ABOUT = sourceSizeList(
   sourceSize(withoutHorizontalPagePadding(Vw(35)), minWidth(BREAKPOINT_S_PX)),
@@ -51,15 +55,11 @@ export const logoSizesFromMaxWidth = (maxWidthPx: number) => {
 export const PROJECT_LIST_ITEM = (() => {
   const SLIDES_PER_VIEW = PROJECT_LIST_ITEM_SLIDES_PER_VIEW
   return sourceSizeList(
-    // 👇 TODO: to be accurate, this should be height -> 100vh
-    //          however, this needs a bit of work in this responsive images infra
-    sourceSize(
-      withoutHorizontalPagePadding(Vw(33.3), SLIDES_PER_VIEW),
-      minWidth(BREAKPOINT_M_PX),
-    ),
     sourceSize(
       withoutHorizontalPagePadding(Vw(100 / SLIDES_PER_VIEW), SLIDES_PER_VIEW),
+      maxWidth(BREAKPOINT_M_PX),
     ),
+    heightSourceSize(Vh(100)),
   )
 })()
 


### PR DESCRIPTION
By allowing to specify `max-height` for portrait mode. Not accurate anyway, given it follows common screen resolutions. Was getting too cumbersome. So stoping it here
