### PR TITLE
refactor: encapsulate Swiper.js styles

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -66,7 +66,7 @@
                 {
                   "type": "anyComponentStyle",
                   "maximumWarning": "2kb",
-                  "maximumError": "14kb"
+                  "maximumError": "16kb"
                 }
               ],
               "outputHashing": "all"

--- a/src/app/projects/images-swiper/images-swiper.component.scss
+++ b/src/app/projects/images-swiper/images-swiper.component.scss
@@ -1,17 +1,26 @@
 @use 'logo';
 @use 'theme';
+@use 'sass:meta';
 
-@forward 'swiper/scss';
-@forward 'swiper/scss/a11y';
-@forward 'swiper/scss/autoplay';
-@forward 'swiper/scss/keyboard';
-@forward 'swiper/scss/navigation';
-@forward 'swiper/scss/pagination';
-@forward 'swiper/scss/virtual';
+:host {
+  ::ng-deep {
+    @include meta.load-css('swiper/scss');
+    @include meta.load-css('swiper/scss/a11y');
+    @include meta.load-css('swiper/scss/autoplay');
+    @include meta.load-css('swiper/scss/keyboard');
+    @include meta.load-css('swiper/scss/navigation');
+    @include meta.load-css('swiper/scss/pagination');
+    @include meta.load-css('swiper/scss/virtual');
+  }
 
-@at-root {
-  :root {
+  & {
+    //👇 Given imported Swiper.js styles are nested within `:host`,
+    //   @at-root + `:root` blocks output `[_nghost-...] :root` CSS. Example:
+    //   https://github.com/nolimits4web/swiper/blob/v11.2.6/src/modules/navigation/navigation.scss#L2-L4
+    //   Therefore they do not apply. So writing them manually here.
+    //   Theme color is actually needed anyway to overwrite default one.
     --swiper-theme-color: #{theme.$accent};
+    --swiper-navigation-size: 44px;
   }
 }
 

--- a/src/app/projects/images-swiper/images-swiper.component.ts
+++ b/src/app/projects/images-swiper/images-swiper.component.ts
@@ -1,10 +1,4 @@
-import {
-  Component,
-  computed,
-  inject,
-  input,
-  ViewEncapsulation,
-} from '@angular/core'
+import { Component, computed, inject, input } from '@angular/core'
 import { SwiperOptions } from 'swiper/types'
 import {
   A11y,
@@ -25,7 +19,6 @@ import { SwiperAutoplayScrollDirective } from './swiper-autoplay-scroll.directiv
   selector: 'app-images-swiper',
   templateUrl: './images-swiper.component.html',
   styleUrls: ['./images-swiper.component.scss'],
-  encapsulation: ViewEncapsulation.None,
   imports: [SwiperDirective, SwiperAutoplayScrollDirective],
 })
 export class ImagesSwiperComponent {


### PR DESCRIPTION
Encapsulate Swiper.js styles so that they do not apply to other components. Budget has been increased as this extra `:host` CSS is output. Which is 1.88kB more. After compression the increase will be much lower though. So going for it. Trade-offs.

> To be honest, not sure those styles are part of images swiper. They should probably come from Swiper.js directive. Not sure how to make that a directive imports some styles when used though. So going with this anyway. Learned about `meta.load-css` which is a win anyway :P Can't use `@use` as they can't be used in nested blocks. `@imports` could be used. But they're deprecated. This is the way to go now for these scenarios.